### PR TITLE
Mplot data reconfiguration

### DIFF
--- a/marmot/marmot_plot_main.py
+++ b/marmot/marmot_plot_main.py
@@ -31,6 +31,7 @@ except ModuleNotFoundError:
 from marmot.utils.loggersetup import SetupLogger
 from marmot.utils.definitions import INPUT_DIR, Module_CLASS_MAPPING
 from marmot.metamanagers.read_metadata import MetaData
+from marmot.plottingmodules.plotutils.plot_data_helper import GenCategories
 from marmot.plottingmodules.plotutils.styles import GeneratorColorDict, PlotMarkers, ColorList
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     DataSavedInModule,
@@ -307,6 +308,7 @@ class MarmotPlot(SetupLogger):
                 self.ordered_gen_categories["Ordered_Gen"].str.strip().tolist()
             )
 
+        gen_categories = GenCategories().set_categories(self.ordered_gen_categories)
         # If Other category does not exist in ordered_gen, create entry
         if "Other" not in ordered_gen:
             ordered_gen.append("Other")
@@ -318,9 +320,6 @@ class MarmotPlot(SetupLogger):
                 "'Color dictionary' not passed! Random colors will now be used."
             )
             marmot_color_dict = GeneratorColorDict.set_random_colors(ordered_gen).color_dict
-
-        color_list = ColorList().colors
-        marker_style = PlotMarkers().markers
 
         gen_names_dict = (
             self.gen_names[["Original", "New"]].set_index("Original").to_dict()["New"]
@@ -464,20 +463,20 @@ class MarmotPlot(SetupLogger):
                 self.Scenarios,
                 self.AGG_BY,
                 ordered_gen,
-                self.marmot_solutions_folder
+                self.marmot_solutions_folder,
             ]
             # dictionary of keyword arguments passed to plotting modules;
             # key names match the instance variables in each module
             argument_dict = {
                 "gen_names_dict": gen_names_dict,
-                "gen_categories": self.ordered_gen_categories,
+                "gen_categories": gen_categories,
                 "marmot_color_dict": marmot_color_dict,
                 "Scenario_Diff": self.Scenario_Diff,
                 "ylabels": self.ylabels,
                 "xlabels": self.xlabels,
                 "custom_xticklabels": self.custom_xticklabels,
-                "color_list": color_list,
-                "marker_style": marker_style,
+                "color_list": ColorList().colors,
+                "marker_style": PlotMarkers().markers,
                 "Region_Mapping": self.Region_Mapping,
                 "TECH_SUBSET": self.TECH_SUBSET,
             }
@@ -488,7 +487,6 @@ class MarmotPlot(SetupLogger):
 
             class_name = getattr(plot_module, Module_CLASS_MAPPING[module])
             instantiate_mplot = class_name(*argument_list, **argument_dict)
-
             # Create output folder for each plotting module
             figures : Path = instantiate_mplot.figure_folder.joinpath(f"{self.AGG_BY}_{module}")
             figures.mkdir(exist_ok=True)

--- a/marmot/marmot_plot_main.py
+++ b/marmot/marmot_plot_main.py
@@ -31,6 +31,7 @@ except ModuleNotFoundError:
 from marmot.utils.loggersetup import SetupLogger
 from marmot.utils.definitions import INPUT_DIR, Module_CLASS_MAPPING
 from marmot.metamanagers.read_metadata import MetaData
+from marmot.plottingmodules.plotutils.styles import GeneratorColorDict, PlotMarkers, ColorList
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     DataSavedInModule,
     InputSheetError,
@@ -311,36 +312,15 @@ class MarmotPlot(SetupLogger):
             ordered_gen.append("Other")
 
         if self.color_dictionary_file is not None:
-            PLEXOS_color_dict = self.color_dictionary_file.rename(
-                columns={
-                    self.color_dictionary_file.columns[0]: "Generator",
-                    self.color_dictionary_file.columns[1]: "Colour",
-                }
-            )
-
-            PLEXOS_color_dict["Generator"] = PLEXOS_color_dict["Generator"].str.strip()
-            PLEXOS_color_dict["Colour"] = PLEXOS_color_dict["Colour"].str.strip()
-            PLEXOS_color_dict = (
-                PLEXOS_color_dict[["Generator", "Colour"]]
-                .set_index("Generator")
-                .to_dict()["Colour"]
-            )
+            marmot_color_dict = GeneratorColorDict.set_colors_from_df(self.color_dictionary_file).color_dict
         else:
-            PLEXOS_color_dict = None
+            self.logger.warning(
+                "'Color dictionary' not passed! Random colors will now be used."
+            )
+            marmot_color_dict = GeneratorColorDict.set_random_colors(ordered_gen).color_dict
 
-        color_list = [
-            "#396AB1",
-            "#CC2529",
-            "#3E9651",
-            "#ff7f00",
-            "#6B4C9A",
-            "#922428",
-            "#cab2d6",
-            "#6a3d9a",
-            "#fb9a99",
-            "#b15928"
-        ]
-        marker_style = ["^", "*", "o", "D", "x", "<", "P", "H", "8", "+"]
+        color_list = ColorList().colors
+        marker_style = PlotMarkers().markers
 
         gen_names_dict = (
             self.gen_names[["Original", "New"]].set_index("Original").to_dict()["New"]
@@ -491,7 +471,7 @@ class MarmotPlot(SetupLogger):
             argument_dict = {
                 "gen_names_dict": gen_names_dict,
                 "gen_categories": self.ordered_gen_categories,
-                "PLEXOS_color_dict": PLEXOS_color_dict,
+                "marmot_color_dict": marmot_color_dict,
                 "Scenario_Diff": self.Scenario_Diff,
                 "ylabels": self.ylabels,
                 "xlabels": self.xlabels,

--- a/marmot/plottingmodules/capacity_factor.py
+++ b/marmot/plottingmodules/capacity_factor.py
@@ -8,10 +8,13 @@ of generators and average output plots
 import logging
 import numpy as np
 import pandas as pd
+from typing import List
 
 import marmot.utils.mconfig as mconfig
 
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.styles import ColorList
+
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
@@ -22,28 +25,37 @@ logger = logging.getLogger("plotter." + __name__)
 plot_data_settings = mconfig.parser("plot_data")
 
 
-class CapacityFactor(MPlotDataHelper):
+class CapacityFactor(PlotDataStoreAndProcessor):
     """Generator capacity factor plots.
 
     The capacity_factor.py module contain methods that are
     related to the capacity factor of generators.
 
-    CapacityFactor inherits from the MPlotDataHelper class to
+    CapacityFactor inherits from the PlotDataStoreAndProcessor class to
     assist in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args, 
+        color_list: list = ColorList().colors,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        self.color_list = color_list
 
         self.x = mconfig.parser("figure_size", "xdimension")
         self.y = mconfig.parser("figure_size", "ydimension")
@@ -87,7 +99,7 @@ class CapacityFactor(MPlotDataHelper):
             (True, "generator_Installed_Capacity", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper 
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor 
         # dictionary with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -255,7 +267,7 @@ class CapacityFactor(MPlotDataHelper):
             (True, "generator_Installed_Capacity", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper 
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor 
         # dictionary with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -376,7 +388,7 @@ class CapacityFactor(MPlotDataHelper):
             (True, "generator_Hours_at_Minimum", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 

--- a/marmot/plottingmodules/capacity_factor.py
+++ b/marmot/plottingmodules/capacity_factor.py
@@ -23,7 +23,9 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
+xdimension: int = mconfig.parser("figure_size", "xdimension")
+ydimension: int = mconfig.parser("figure_size", "ydimension")
 
 
 class CapacityFactor(PlotDataStoreAndProcessor):
@@ -66,9 +68,6 @@ class CapacityFactor(PlotDataStoreAndProcessor):
         self.Scenarios = Scenarios
         self.gen_categories = gen_categories
         self.color_list = color_list
-
-        self.x = mconfig.parser("figure_size", "xdimension")
-        self.y = mconfig.parser("figure_size", "ydimension")
 
     def avg_output_when_committed(
         self,
@@ -341,7 +340,7 @@ class CapacityFactor(PlotDataStoreAndProcessor):
 
             Data_Table_Out = CF_all_scenarios.T
 
-            mplt = PlotLibrary(figsize=(self.x * 1.5, self.y * 1.5))
+            mplt = PlotLibrary(figsize=(xdimension * 1.5, ydimension * 1.5))
             fig, ax = mplt.get_figure()
 
             mplt.barplot(
@@ -477,7 +476,7 @@ class CapacityFactor(PlotDataStoreAndProcessor):
 
             Data_Table_Out = time_at_min.T
 
-            mplt = PlotLibrary(figsize=(self.x * 1.5, self.y * 1.5))
+            mplt = PlotLibrary(figsize=(xdimension * 1.5, ydimension * 1.5))
             fig, ax = mplt.get_figure()
 
             mplt.barplot(

--- a/marmot/plottingmodules/capacity_out.py
+++ b/marmot/plottingmodules/capacity_out.py
@@ -12,11 +12,12 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
-
+from typing import List
 import marmot.utils.mconfig as mconfig
 
+from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     UnderDevelopment,
@@ -28,28 +29,44 @@ plot_data_settings = mconfig.parser("plot_data")
 shift_leapday: bool = mconfig.parser("shift_leapday")
 
 
-class CapacityOut(MPlotDataHelper):
+class CapacityOut(PlotDataStoreAndProcessor):
     """Generator outage plots.
 
     The capacity_out.py module contains methods that are
     related to generators that are on an outage.
 
-    CapacityOut inherits from the MPlotDataHelper class to assist
+    CapacityOut inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args,
+        marmot_color_dict: dict = None,
+        ylabels: List[str] = None,
+        xlabels: List[str] = None,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        if marmot_color_dict is None:
+            self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
+        else:
+            self.marmot_color_dict = marmot_color_dict
+        self.ylabels = ylabels
+        self.xlabels = xlabels
 
     def capacity_out_stack(
         self,
@@ -86,7 +103,7 @@ class CapacityOut(MPlotDataHelper):
             (True, f"generator_Available_Capacity{data_resolution}", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -179,7 +196,7 @@ class CapacityOut(MPlotDataHelper):
 
                 mplt.stackplot(
                     df=cap_out,
-                    color_dict=self.PLEXOS_color_dict,
+                    color_dict=self.marmot_color_dict,
                     labels=cap_out.columns,
                     sub_pos=i,
                 )
@@ -322,7 +339,7 @@ class CapacityOut(MPlotDataHelper):
                         labels=one_zone.columns,
                         linewidth=0,
                         colors=[
-                            self.PLEXOS_color_dict.get(x, "#333333")
+                            self.marmot_color_dict.get(x, "#333333")
                             for x in one_zone.T.index
                         ],
                     )
@@ -358,7 +375,7 @@ class CapacityOut(MPlotDataHelper):
                         labels=one_zone.columns,
                         linewidth=0,
                         colors=[
-                            self.PLEXOS_color_dict.get(x, "#333333")
+                            self.marmot_color_dict.get(x, "#333333")
                             for x in one_zone.T.index
                         ],
                     )

--- a/marmot/plottingmodules/capacity_out.py
+++ b/marmot/plottingmodules/capacity_out.py
@@ -27,7 +27,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 shift_leapday: bool = mconfig.parser("shift_leapday")
 
 

--- a/marmot/plottingmodules/curtailment.py
+++ b/marmot/plottingmodules/curtailment.py
@@ -25,8 +25,8 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
-
+plot_data_settings: dict = mconfig.parser("plot_data")
+curtailment_prop: str = mconfig.parser("plot_data", "curtailment_property")
 
 class Curtailment(PlotDataStoreAndProcessor):
     """Device curtailment plots.
@@ -87,7 +87,6 @@ class Curtailment(PlotDataStoreAndProcessor):
         self.color_list = color_list
         self.marker_style = marker_style
 
-        self.curtailment_prop: str = mconfig.parser("plot_data", "curtailment_property")
 
     def curt_duration_curve(
         self,
@@ -119,7 +118,7 @@ class Curtailment(PlotDataStoreAndProcessor):
         # List of properties needed by the plot, properties are a set of tuples and 
         # contain 3 parts: required True/False, property name and scenarios required, 
         # scenarios must be a list.
-        properties = [(True, f"generator_{self.curtailment_prop}", self.Scenarios)]
+        properties = [(True, f"generator_{curtailment_prop}", self.Scenarios)]
 
         # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
@@ -137,7 +136,7 @@ class Curtailment(PlotDataStoreAndProcessor):
             for scenario in self.Scenarios:
                 logger.info(f"Scenario = {scenario}")
 
-                re_curt = self[f"generator_{self.curtailment_prop}"].get(scenario)
+                re_curt = self[f"generator_{curtailment_prop}"].get(scenario)
 
                 # Timeseries [MW] RE curtailment [MWh]
                 try:  # Check for regions missing all generation.
@@ -148,7 +147,7 @@ class Curtailment(PlotDataStoreAndProcessor):
 
                 re_curt = self.df_process_gen_inputs(re_curt)
                 # If using Marmot's curtailment property
-                if self.curtailment_prop == "Curtailment":
+                if curtailment_prop == "Curtailment":
                     re_curt = self.assign_curtailment_techs(re_curt, self.gen_categories.vre)
 
                 # Timeseries [MW] PV curtailment [MWh]
@@ -303,7 +302,7 @@ class Curtailment(PlotDataStoreAndProcessor):
         properties = [
             (True, "generator_Generation", self.Scenarios),
             (True, "generator_Available_Capacity", self.Scenarios),
-            (True, f"generator_{self.curtailment_prop}", self.Scenarios),
+            (True, f"generator_{curtailment_prop}", self.Scenarios),
             (True, "generator_Total_Generation_Cost", self.Scenarios),
         ]
 
@@ -332,7 +331,7 @@ class Curtailment(PlotDataStoreAndProcessor):
                 avail_gen = self["generator_Available_Capacity"].get(scenario)
                 avail_gen = avail_gen.xs(zone_input, level=self.AGG_BY)
 
-                re_curt = self[f"generator_{self.curtailment_prop}"].get(scenario)
+                re_curt = self[f"generator_{curtailment_prop}"].get(scenario)
                 try:
                     re_curt = re_curt.xs(zone_input, level=self.AGG_BY)
                 except KeyError:
@@ -341,7 +340,7 @@ class Curtailment(PlotDataStoreAndProcessor):
 
                 re_curt = self.df_process_gen_inputs(re_curt)
                 # If using Marmot's curtailment property
-                if self.curtailment_prop == "Curtailment":
+                if curtailment_prop == "Curtailment":
                     re_curt = self.assign_curtailment_techs(re_curt, self.gen_categories.vre)
 
                 # Total generation cost
@@ -591,7 +590,7 @@ class Curtailment(PlotDataStoreAndProcessor):
         # contain 3 parts: required True/False, property name and scenarios required, 
         # scenarios must be a list.
         properties = [
-            (True, f"generator_{self.curtailment_prop}", self.Scenarios),
+            (True, f"generator_{curtailment_prop}", self.Scenarios),
             (False, "generator_Available_Capacity", self.Scenarios),
         ]
 
@@ -611,7 +610,7 @@ class Curtailment(PlotDataStoreAndProcessor):
             for scenario in self.Scenarios:
                 logger.info(f"Scenario = {scenario}")
 
-                vre_curt = self[f"generator_{self.curtailment_prop}"].get(scenario)
+                vre_curt = self[f"generator_{curtailment_prop}"].get(scenario)
                 try:
                     vre_curt = vre_curt.xs(zone_input, level=self.AGG_BY)
                 except KeyError:
@@ -620,12 +619,12 @@ class Curtailment(PlotDataStoreAndProcessor):
 
                 vre_curt = self.df_process_gen_inputs(vre_curt)
                 # If using Marmot's curtailment property
-                if self.curtailment_prop == "Curtailment":
+                if curtailment_prop == "Curtailment":
                     vre_curt = self.assign_curtailment_techs(vre_curt, self.gen_categories.vre)
 
                 avail_gen = self["generator_Available_Capacity"].get(scenario)
                 if avail_gen.empty:
-                    avail_gen = self[f"generator_{self.curtailment_prop}"][
+                    avail_gen = self[f"generator_{curtailment_prop}"][
                         scenario
                     ].copy()
                     avail_gen.iloc[:, 0] = 0
@@ -637,7 +636,7 @@ class Curtailment(PlotDataStoreAndProcessor):
 
                 avail_gen = self.df_process_gen_inputs(avail_gen)
                 # If using Marmot's curtailment property
-                if self.curtailment_prop == "Curtailment":
+                if curtailment_prop == "Curtailment":
                     avail_gen = self.assign_curtailment_techs(avail_gen, self.gen_categories.vre)
 
                 if pd.notna(start_date_range):
@@ -774,7 +773,7 @@ class Curtailment(PlotDataStoreAndProcessor):
 
         outputs: dict = {}
         properties = [
-            (True, f"generator_{self.curtailment_prop}", self.Scenarios),
+            (True, f"generator_{curtailment_prop}", self.Scenarios),
             (True, "generator_Available_Capacity", self.Scenarios),
         ]
 
@@ -804,7 +803,7 @@ class Curtailment(PlotDataStoreAndProcessor):
                 vre_collection = {}
                 avail_vre_collection = {}
 
-                vre_curt = self[f"generator_{self.curtailment_prop}"].get(scenario)
+                vre_curt = self[f"generator_{curtailment_prop}"].get(scenario)
                 try:
                     vre_curt = vre_curt.xs(zone_input, level=self.AGG_BY)
                 except KeyError:
@@ -812,7 +811,7 @@ class Curtailment(PlotDataStoreAndProcessor):
                     continue
                 vre_curt = self.df_process_gen_inputs(vre_curt)
                 # If using Marmot's curtailment property
-                if self.curtailment_prop == "Curtailment":
+                if curtailment_prop == "Curtailment":
                     vre_curt = self.assign_curtailment_techs(vre_curt, self.gen_categories.vre)
 
                 avail_gen = self["generator_Available_Capacity"].get(scenario)
@@ -824,7 +823,7 @@ class Curtailment(PlotDataStoreAndProcessor):
 
                 avail_gen = self.df_process_gen_inputs(avail_gen)
                 # If using Marmot's curtailment property
-                if self.curtailment_prop == "Curtailment":
+                if curtailment_prop == "Curtailment":
                     avail_gen = self.assign_curtailment_techs(avail_gen, self.gen_categories.vre)
 
                 for vre_type in self.gen_categories.vre:
@@ -979,7 +978,7 @@ class Curtailment(PlotDataStoreAndProcessor):
         # scenarios must be a list.
         properties = [
             (True, "generator_Generation", self.Scenarios),
-            (True, f"generator_{self.curtailment_prop}", self.Scenarios),
+            (True, f"generator_{curtailment_prop}", self.Scenarios),
         ]
 
         # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
@@ -1000,7 +999,7 @@ class Curtailment(PlotDataStoreAndProcessor):
             scen_idx += 1
             logger.info(f"Scenario = {scenario}")
 
-            vre_curt: pd.DataFrame = self[f"generator_{self.curtailment_prop}"].get(
+            vre_curt: pd.DataFrame = self[f"generator_{curtailment_prop}"].get(
                 scenario
             )
             gen: pd.DataFrame = self["generator_Generation"].get(scenario)
@@ -1186,7 +1185,7 @@ class Curtailment(PlotDataStoreAndProcessor):
         # List of properties needed by the plot, properties are a set of tuples and 
         # contain 3 parts: required True/False, property name and scenarios required, 
         # scenarios must be a list.
-        properties = [(True, f"generator_{self.curtailment_prop}", self.Scenarios)]
+        properties = [(True, f"generator_{curtailment_prop}", self.Scenarios)]
 
         # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
@@ -1202,7 +1201,7 @@ class Curtailment(PlotDataStoreAndProcessor):
             for scenario in self.Scenarios:
                 logger.info(f"Scenario = {scenario}")
 
-                re_curt = self[f"generator_{self.curtailment_prop}"].get(scenario)
+                re_curt = self[f"generator_{curtailment_prop}"].get(scenario)
                 try:
                     re_curt = re_curt.xs(zone_input, level=self.AGG_BY)
                 except KeyError:
@@ -1211,7 +1210,7 @@ class Curtailment(PlotDataStoreAndProcessor):
 
                 re_curt = self.df_process_gen_inputs(re_curt)
                 # If using Marmot's curtailment property
-                if self.curtailment_prop == "Curtailment":
+                if curtailment_prop == "Curtailment":
                     re_curt = self.assign_curtailment_techs(re_curt, self.gen_categories.vre)
                 # Sum across technologies
                 re_curt = re_curt.sum(axis=1)

--- a/marmot/plottingmodules/emissions.py
+++ b/marmot/plottingmodules/emissions.py
@@ -28,7 +28,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 
 
 class Emissions(PlotDataStoreAndProcessor):

--- a/marmot/plottingmodules/emissions.py
+++ b/marmot/plottingmodules/emissions.py
@@ -19,7 +19,8 @@ import marmot.utils.mconfig as mconfig
 
 from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor, GenCategories
+from marmot.plottingmodules.plotutils.timeseries_modifiers import set_timestamp_date_range
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     InputSheetError,
@@ -43,21 +44,29 @@ class Emissions(PlotDataStoreAndProcessor):
     def __init__(self, 
         Zones: List[str], 
         Scenarios: List[str], 
-        *args, 
+        AGG_BY: str,
+        ordered_gen: List[str],
+        marmot_solutions_folder: Path,
         marmot_color_dict: dict = None,
         custom_xticklabels: List[str] = None,
         **kwargs):
         """
         Args:
-            *args
-                Minimum required parameters passed to the PlotDataStoreAndProcessor 
-                class.
-            **kwargs
-                These parameters will be passed to the PlotDataStoreAndProcessor 
-                class.
+            Zones (List[str]): List of regions/zones to plot.
+            Scenarios (List[str]): List of scenarios to plot.
+            AGG_BY (str): Informs region type to aggregate by when creating plots.
+            ordered_gen (List[str]): Ordered list of generator technologies to plot,
+                order defines the generator technology position in stacked bar and area plots.
+            marmot_solutions_folder (Path): Directory containing Marmot solution outputs.
+            marmot_color_dict (dict, optional): Dictionary of colors to use for 
+                generation technologies.
+                Defaults to None.
+            custom_xticklabels (List[str], optional): List of custom x labels to 
+                apply to barplots. Values will overwite existing ones. 
+                Defaults to None.
         """
-        # Instantiation of MPlotHelperFunctions
-        super().__init__(*args, **kwargs)
+        # Instantiation of PlotDataStoreAndProcessor
+        super().__init__(AGG_BY, ordered_gen, marmot_solutions_folder, **kwargs)
 
         self.Zones = Zones
         self.Scenarios = Scenarios
@@ -138,7 +147,7 @@ class Emissions(PlotDataStoreAndProcessor):
                     continue
 
                 if pd.notna(start_date_range):
-                    emit = self.set_timestamp_date_range(
+                    emit = set_timestamp_date_range(
                         emit, start_date_range, end_date_range
                     )
                     if emit.empty:

--- a/marmot/plottingmodules/emissions.py
+++ b/marmot/plottingmodules/emissions.py
@@ -12,12 +12,14 @@ TO DO:
 
 import logging
 import pandas as pd
+from typing import List
 from pathlib import Path
 
 import marmot.utils.mconfig as mconfig
 
+from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     InputSheetError,
@@ -28,28 +30,42 @@ logger = logging.getLogger("plotter." + __name__)
 plot_data_settings = mconfig.parser("plot_data")
 
 
-class Emissions(MPlotDataHelper):
+class Emissions(PlotDataStoreAndProcessor):
     """Generator emissions plots.
 
     The emissions.py module contains methods that are
     related to the fossil fuel emissions of generators.
 
-    Emissions inherits from the MPlotDataHelper class to assist
+    Emissions inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args, 
+        marmot_color_dict: dict = None,
+        custom_xticklabels: List[str] = None,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        if marmot_color_dict is None:
+            self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
+        else:
+            self.marmot_color_dict = marmot_color_dict
+        self.custom_xticklabels = custom_xticklabels
 
     def total_emissions_by_type(
         self,
@@ -94,7 +110,7 @@ class Emissions(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "emissions_generators_Production", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -191,7 +207,7 @@ class Emissions(MPlotDataHelper):
 
             mplt.barplot(
                 emitPlot,
-                color=self.PLEXOS_color_dict,
+                color=self.marmot_color_dict,
                 stacked=True,
                 custom_tick_labels=tick_labels,
             )

--- a/marmot/plottingmodules/generation_stack.py
+++ b/marmot/plottingmodules/generation_stack.py
@@ -29,7 +29,7 @@ logger = logging.getLogger("plotter." + __name__)
 plot_data_settings: dict = mconfig.parser("plot_data")
 shift_leapday: bool = mconfig.parser("shift_leapday")
 load_legend_names: dict = mconfig.parser("load_legend_names")
-
+curtailment_prop: str = mconfig.parser("plot_data", "curtailment_property")
 
 class GenerationStack(PlotDataStoreAndProcessor):
     """Timeseries generation stacked area plots.
@@ -93,7 +93,6 @@ class GenerationStack(PlotDataStoreAndProcessor):
         else:
             self.Scenario_Diff = Scenario_Diff
 
-        self.curtailment_prop = mconfig.parser("plot_data", "curtailment_property")
 
     def committed_stack(
         self,
@@ -349,7 +348,7 @@ class GenerationStack(PlotDataStoreAndProcessor):
         # scenarios must be a list.
         properties = [
             (True, f"generator_Generation{data_resolution}", self.Scenarios),
-            (False,f"generator_{self.curtailment_prop}{data_resolution}",self.Scenarios),
+            (False,f"generator_{curtailment_prop}{data_resolution}",self.Scenarios),
             (False, f"{agg}_Load{data_resolution}", self.Scenarios),
             (False, f"{agg}_Demand{data_resolution}", self.Scenarios),
             (False, f"{agg}_Unserved_Energy{data_resolution}", self.Scenarios),
@@ -493,7 +492,7 @@ class GenerationStack(PlotDataStoreAndProcessor):
                         stacked_gen_df = stacked_gen_df.loc[start_date:end_date]
                         extra_plot_data = extra_plot_data.loc[start_date:end_date]
 
-                if mconfig.parser("plot_data", "include_stackplot_net_imports"):
+                if plot_data_settings["include_stackplot_net_imports"]:
                     stacked_gen_df = self.include_net_imports(
                         stacked_gen_df,
                         extra_plot_data["Total Load"],

--- a/marmot/plottingmodules/generation_unstack.py
+++ b/marmot/plottingmodules/generation_unstack.py
@@ -9,12 +9,14 @@ import numpy as np
 import pandas as pd
 import datetime as dt
 import matplotlib.pyplot as plt
+from pathlib import Path
 import marmot.utils.mconfig as mconfig
 from typing import List
 
 from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import SetupSubplot
-from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor, GenCategories, set_facet_col_row_dimensions
+from marmot.plottingmodules.plotutils.timeseries_modifiers import set_timestamp_date_range, adjust_for_leapday
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -39,25 +41,39 @@ class GenerationUnStack(PlotDataStoreAndProcessor):
     def __init__(self, 
         Zones: List[str], 
         Scenarios: List[str], 
-        *args, 
+        AGG_BY: str,
+        ordered_gen: List[str],
+        marmot_solutions_folder: Path,
+        gen_categories: GenCategories = GenCategories(),
         marmot_color_dict: dict = None,
         ylabels: List[str] = None,
         xlabels: List[str] = None,
         **kwargs):
         """
         Args:
-            *args
-                Minimum required parameters passed to the PlotDataStoreAndProcessor 
-                class.
-            **kwargs
-                These parameters will be passed to the PlotDataStoreAndProcessor 
-                class.
+            Zones (List[str]): List of regions/zones to plot.
+            Scenarios (List[str]): List of scenarios to plot.
+            AGG_BY (str): Informs region type to aggregate by when creating plots.
+            ordered_gen (List[str]): Ordered list of generator technologies to plot,
+                order defines the generator technology position in stacked bar and area plots.
+            marmot_solutions_folder (Path): Directory containing Marmot solution outputs.
+            gen_categories (GenCategories): Instance of GenCategories class, groups generator technologies 
+                into defined categories.
+                Deafults to GenCategories.
+            marmot_color_dict (dict, optional): Dictionary of colors to use for 
+                generation technologies.
+                Defaults to None.
+            ylabels (List[str], optional): y-axis labels for facet plots.
+                Defaults to None.
+            xlabels (List[str], optional): x-axis labels for facet plots.
+                Defaults to None.        
         """
-        # Instantiation of MPlotHelperFunctions
-        super().__init__(*args, **kwargs)
+        # Instantiation of PlotDataStoreAndProcessor
+        super().__init__(AGG_BY, ordered_gen, marmot_solutions_folder, **kwargs)
 
         self.Zones = Zones
         self.Scenarios = Scenarios
+        self.gen_categories = gen_categories
         if marmot_color_dict is None:
             self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
         else:
@@ -153,7 +169,7 @@ class GenerationUnStack(PlotDataStoreAndProcessor):
             return outputs
 
         # sets up x, y dimensions of plot
-        ncols, nrows = self.set_facet_col_row_dimensions(multi_scenario=all_scenarios)
+        ncols, nrows = set_facet_col_row_dimensions(self.xlabels, self.ylabels, multi_scenario=all_scenarios)
 
         grid_size = ncols * nrows
 
@@ -192,7 +208,7 @@ class GenerationUnStack(PlotDataStoreAndProcessor):
                         .copy()
                     )
                     if shift_leapday:
-                        stacked_gen_df = self.adjust_for_leapday(stacked_gen_df)
+                        stacked_gen_df = adjust_for_leapday(stacked_gen_df)
                     stacked_gen_df = stacked_gen_df.xs(zone_input, level=self.AGG_BY)
                 except KeyError:
                     logger.warning(f"No generation in {zone_input}")
@@ -205,7 +221,7 @@ class GenerationUnStack(PlotDataStoreAndProcessor):
 
                 # Insert Curtailment into gen stack if it exists in database
                 stacked_gen_df = self.add_curtailment_to_df(stacked_gen_df, scenario,
-                    zone_input, data_resolution=data_resolution)
+                    zone_input, self.gen_categories.vre, data_resolution=data_resolution)
                 
                 curtailment_name = self.gen_names_dict.get("Curtailment", "Curtailment")
                 if curtailment_name in stacked_gen_df.columns:
@@ -214,7 +230,7 @@ class GenerationUnStack(PlotDataStoreAndProcessor):
                     vre_gen_cat = self.gen_categories.vre
 
                 if pd.notna(start_date_range):
-                    stacked_gen_df = self.set_timestamp_date_range(
+                    stacked_gen_df = set_timestamp_date_range(
                         stacked_gen_df, start_date_range, end_date_range
                     )
                     if stacked_gen_df.empty is True:
@@ -251,7 +267,7 @@ class GenerationUnStack(PlotDataStoreAndProcessor):
                 # unitconversion based off peak generation hour, only checked once
                 if i == 0:
                     unitconversion = self.capacity_energy_unitconversion(
-                        stacked_gen_df, sum_values=True
+                        stacked_gen_df, self.Scenarios, sum_values=True
                     )
                 # Convert units
                 stacked_gen_df = stacked_gen_df / unitconversion["divisor"]

--- a/marmot/plottingmodules/generation_unstack.py
+++ b/marmot/plottingmodules/generation_unstack.py
@@ -10,10 +10,11 @@ import pandas as pd
 import datetime as dt
 import matplotlib.pyplot as plt
 import marmot.utils.mconfig as mconfig
+from typing import List
 
-
+from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import SetupSubplot
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -24,29 +25,45 @@ plot_data_settings = mconfig.parser("plot_data")
 shift_leapday: bool = mconfig.parser("shift_leapday")
 
 
-class GenerationUnStack(MPlotDataHelper):
+class GenerationUnStack(PlotDataStoreAndProcessor):
     """Timeseries generation line plots.
 
     The generation_unstack.py module contains methods that are
     related to the timeseries generation of generators,
     displayed in an unstacked line format.
 
-    GenerationUnStack inherits from the MPlotDataHelper class to assist
+    GenerationUnStack inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args, 
+        marmot_color_dict: dict = None,
+        ylabels: List[str] = None,
+        xlabels: List[str] = None,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        if marmot_color_dict is None:
+            self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
+        else:
+            self.marmot_color_dict = marmot_color_dict
+        self.ylabels = ylabels
+        self.xlabels = xlabels
 
         self.curtailment_prop = mconfig.parser("plot_data", "curtailment_property")
 
@@ -123,7 +140,7 @@ class GenerationUnStack(MPlotDataHelper):
                 (False, f"{agg}_Unserved_Energy{data_resolution}", scenario_list),
             ]
 
-            # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+            # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
             # with all required properties, returns a 1 if required data is missing
             return self.get_formatted_data(properties)
 
@@ -283,7 +300,7 @@ class GenerationUnStack(MPlotDataHelper):
                         stacked_gen_df.index.values,
                         stacked_gen_df[column],
                         linewidth=2,
-                        color=self.PLEXOS_color_dict.get(column, "#333333"),
+                        color=self.marmot_color_dict.get(column, "#333333"),
                         label=column,
                     )
 

--- a/marmot/plottingmodules/generation_unstack.py
+++ b/marmot/plottingmodules/generation_unstack.py
@@ -23,9 +23,9 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 shift_leapday: bool = mconfig.parser("shift_leapday")
-
+curtailment_prop: str = mconfig.parser("plot_data", "curtailment_property")
 
 class GenerationUnStack(PlotDataStoreAndProcessor):
     """Timeseries generation line plots.
@@ -81,7 +81,6 @@ class GenerationUnStack(PlotDataStoreAndProcessor):
         self.ylabels = ylabels
         self.xlabels = xlabels
 
-        self.curtailment_prop = mconfig.parser("plot_data", "curtailment_property")
 
     def gen_unstack(
         self,
@@ -148,7 +147,7 @@ class GenerationUnStack(PlotDataStoreAndProcessor):
                 (True, f"generator_Generation{data_resolution}", scenario_list),
                 (
                     False,
-                    f"generator_{self.curtailment_prop}{data_resolution}",
+                    f"generator_{curtailment_prop}{data_resolution}",
                     scenario_list,
                 ),
                 (False, f"{agg}_Load{data_resolution}", scenario_list),

--- a/marmot/plottingmodules/hydro.py
+++ b/marmot/plottingmodules/hydro.py
@@ -14,11 +14,12 @@ import logging
 import pandas as pd
 import datetime as dt
 import matplotlib.ticker as mtick
-
+from typing import List
 import marmot.utils.mconfig as mconfig
 
+from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import SetupSubplot
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     DataSavedInModule,
@@ -30,28 +31,40 @@ logger = logging.getLogger("plotter." + __name__)
 plot_data_settings = mconfig.parser("plot_data")
 
 
-class Hydro(MPlotDataHelper):
+class Hydro(PlotDataStoreAndProcessor):
     """Hydro generator plots.
 
     The hydro.py module contains methods that are
     related to hydro generators.
 
-    Hydro inherits from the MPlotDataHelper class to
+    Hydro inherits from the PlotDataStoreAndProcessor class to
     assist in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args, 
+        marmot_color_dict: dict = None,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        if marmot_color_dict is None:
+            self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
+        else:
+            self.marmot_color_dict = marmot_color_dict
 
     def hydro_continent_net_load(
         self, start_date_range: str = None, end_date_range: str = None, **_
@@ -77,7 +90,7 @@ class Hydro(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "generator_Generation", [self.Scenarios[0]])]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -206,7 +219,7 @@ class Hydro(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "generator_Generation", [self.Scenarios[0]])]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -273,7 +286,7 @@ class Hydro(MPlotDataHelper):
                 ax.plot(
                     Hydro_Period,
                     linewidth=2,
-                    color=self.PLEXOS_color_dict.get("Hydro", "#333333"),
+                    color=self.marmot_color_dict.get("Hydro", "#333333"),
                     label="Hydro",
                 )
 

--- a/marmot/plottingmodules/hydro.py
+++ b/marmot/plottingmodules/hydro.py
@@ -29,7 +29,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 
 
 class Hydro(PlotDataStoreAndProcessor):

--- a/marmot/plottingmodules/hydro.py
+++ b/marmot/plottingmodules/hydro.py
@@ -15,11 +15,12 @@ import pandas as pd
 import datetime as dt
 import matplotlib.ticker as mtick
 from typing import List
+from pathlib import Path
 import marmot.utils.mconfig as mconfig
 
 from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import SetupSubplot
-from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor, GenCategories
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     DataSavedInModule,
@@ -44,23 +45,33 @@ class Hydro(PlotDataStoreAndProcessor):
     def __init__(self, 
         Zones: List[str], 
         Scenarios: List[str], 
-        *args, 
+        AGG_BY: str,
+        ordered_gen: List[str],
+        marmot_solutions_folder: Path,
+        gen_categories: GenCategories = GenCategories(),
         marmot_color_dict: dict = None,
         **kwargs):
         """
         Args:
-            *args
-                Minimum required parameters passed to the PlotDataStoreAndProcessor 
-                class.
-            **kwargs
-                These parameters will be passed to the PlotDataStoreAndProcessor 
-                class.
+            Zones (List[str]): List of regions/zones to plot.
+            Scenarios (List[str]): List of scenarios to plot.
+            AGG_BY (str): Informs region type to aggregate by when creating plots.
+            ordered_gen (List[str]): Ordered list of generator technologies to plot,
+                order defines the generator technology position in stacked bar and area plots.
+            marmot_solutions_folder (Path): Directory containing Marmot solution outputs.
+            gen_categories (GenCategories): Instance of GenCategories class, groups generator technologies 
+                into defined categories.
+                Deafults to GenCategories.
+            marmot_color_dict (dict, optional): Dictionary of colors to use for 
+                generation technologies.
+                Defaults to None.
         """
-        # Instantiation of MPlotHelperFunctions
-        super().__init__(*args, **kwargs)
+        # Instantiation of PlotDataStoreAndProcessor
+        super().__init__(AGG_BY, ordered_gen, marmot_solutions_folder, **kwargs)
 
         self.Zones = Zones
         self.Scenarios = Scenarios
+        self.gen_categories = gen_categories
         if marmot_color_dict is None:
             self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
         else:

--- a/marmot/plottingmodules/plotutils/plot_data_helper.py
+++ b/marmot/plottingmodules/plotutils/plot_data_helper.py
@@ -15,8 +15,6 @@ import concurrent.futures
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Tuple, Union, List
-import matplotlib.colors as mcolors
-import matplotlib.pyplot as plt
 
 import marmot.utils.mconfig as mconfig
 import marmot.utils.dataio as dataio
@@ -83,42 +81,30 @@ class GenCategories:
         return cls(**gen_cat_dict)
 
 
-class MPlotDataHelper(dict):
+class PlotDataStoreAndProcessor(dict):
     """Methods used to assist with the creation of Marmot plots
 
     Collection of Methods to assist with creation of figures,
     including getting and formatting data, setting up plot sizes.
 
-    MPlotDataHelper inherits the python class 'dict' so acts like a 
+    PlotDataStoreAndProcessor inherits the python class 'dict' so acts like a 
     dictionary and stores the formatted data when retrieved by the 
     get_formatted_data method.
     """
 
     def __init__(
         self,
-        Zones: List[str],
-        Scenarios: List[str],
         AGG_BY: str,
         ordered_gen: List[str],
         marmot_solutions_folder: Path,
         gen_names_dict: dict = None,
         gen_categories: pd.DataFrame = pd.DataFrame(),
-        PLEXOS_color_dict: dict = None,
-        Scenario_Diff: List[str] = None,
-        ylabels: List[str] = None,
-        xlabels: List[str] = None,
-        custom_xticklabels: List[str] = None,
-        color_list: List[str] = None,
-        marker_style: List[str] = None,
-        Region_Mapping: pd.DataFrame = pd.DataFrame(),
         TECH_SUBSET: List[str] = None,
         **_,
     ) -> None:
         """
         Args:
-            Zones (List[str]): List of regions/zones to plot.
             AGG_BY (str): Informs region type to aggregate by when creating plots.
-            Scenarios (List[str]): List of scenarios to process.
             ordered_gen (List[str]): Ordered list of generator technologies to plot,
                 order defines the generator technology position in stacked bar and area plots.
             marmot_solutions_folder (Path): Directory containing Marmot solution outputs.
@@ -128,34 +114,11 @@ class MPlotDataHelper(dict):
             gen_categories (pd.Dataframe, optional): Dataframe containing ordered generation 
                 and columns to specify technology categories.
                 Defaults to pd.DataFrame().
-            PLEXOS_color_dict (dict, optional): Dictionary of colors to use for 
-                generation technologies.
-                Defaults to None.
-            Scenario_Diff (List[str], optional): 2 value list, used to compare 2
-                scenarios.
-                Defaults to None.
-            ylabels (List[str], optional): y-axis labels for facet plots.
-                Defaults to None.
-            xlabels (List[str], optional): x-axis labels for facet plots.
-                Defaults to None.
-            custom_xticklabels (List[str], optional): List of custom x labels to 
-                apply to barplots. Values will overwite existing ones. 
-                Defaults to None.
-            color_list (List[str], optional): List of colors for plotting.
-                Defaults to None.
-            marker_style (List[str], optional): List of markers for plotting.
-                Defaults to None.
-            Region_Mapping (pd.DataFrame, optional): Mapping file to map 
-                custom regions/zones to create custom aggregations. 
-                Aggregations are created by grouping PLEXOS regions.
-                Defaults to pd.DataFrame().
             TECH_SUBSET (List[str], optional): Tech subset category to plot.
                 The TECH_SUBSET value should be a column in the
                 ordered_gen_categories.csv. If left None all techs will be plotted
                 Defaults to None.
         """
-        self.Zones = Zones
-        self.Scenarios = Scenarios
         self.AGG_BY = AGG_BY
         self.ordered_gen = ordered_gen
         self.marmot_solutions_folder = Path(marmot_solutions_folder)
@@ -174,52 +137,6 @@ class MPlotDataHelper(dict):
             self.gen_names_dict = gen_names_dict
 
         self.gen_categories: GenCategories = GenCategories.set_categories(gen_categories)
-
-        if PLEXOS_color_dict is None:
-            logger.warning(
-                "'Color dictionary' not passed! Random colors will now be used."
-            )
-            cmap = plt.cm.get_cmap(lut=len(ordered_gen))
-            colors = []
-            for i in range(cmap.N):
-                colors.append(mcolors.rgb2hex(cmap(i)))
-            self.PLEXOS_color_dict = dict(zip(ordered_gen, colors))
-        else:
-            self.PLEXOS_color_dict = PLEXOS_color_dict
-        if Scenario_Diff is None:
-            self.Scenario_Diff = [""]
-        else:
-            self.Scenario_Diff = Scenario_Diff
-        if ylabels is None:
-            self.ylabels = []
-        else:
-            self.ylabels = ylabels
-        if xlabels is None:    
-            self.xlabels = []
-        else:    
-            self.xlabels = xlabels
-        if color_list is None:
-            self.color_list = [
-                "#396AB1",
-                "#CC2529",
-                "#3E9651",
-                "#ff7f00",
-                "#6B4C9A",
-                "#922428",
-                "#cab2d6",
-                "#6a3d9a",
-                "#fb9a99",
-                "#b15928"
-            ]
-        else:
-            self.color_list = color_list
-        if marker_style is None:
-            self.marker_style = ["^", "*", "o", "D", "x", "<", "P", "H", "8", "+"]
-        else:
-            self.marker_style = marker_style
-
-        self.custom_xticklabels = custom_xticklabels
-        self.Region_Mapping = Region_Mapping
         self.TECH_SUBSET = TECH_SUBSET
 
     def get_formatted_data(self, properties: List[tuple]) -> list:
@@ -411,115 +328,6 @@ class MPlotDataHelper(dict):
         df = df.sort_index(axis=axis)
         return df
 
-    def merge_new_agg(self, df: pd.DataFrame) -> pd.DataFrame:
-        # TODO Needs fixing
-        """Adds new region aggregation in the plotting step.
-
-        This allows one to create a new aggregation without re-formatting the .h5 file.
-        Args:
-            df (pd.DataFrame): Dataframe to process.
-
-        Returns:
-            pd.DataFrame: Same dataframe, with new aggregation level added.
-        """
-        agg_new = self.Region_Mapping[["region", self.AGG_BY]]
-        agg_new = agg_new.set_index("region")
-        df = df.merge(agg_new, left_on="region", right_index=True)
-        return df
-
-    def adjust_for_leapday(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Shifts dataframe ahead by one day.
-        
-        Use if a non-leap year time series is modeled with a leap year time index.
-
-        Modeled year must be included in the scenario parent directory name.
-        Args:
-            df (pd.DataFrame): Dataframe to process.
-
-        Returns:
-            pd.DataFrame: Same dataframe, with time index shifted.
-        """
-        if (
-            "2008" not in self.processed_hdf5_folder
-            and "2012" not in self.processed_hdf5_folder
-            and df.index.get_level_values("timestamp")[0]
-            > dt.datetime(2024, 2, 28, 0, 0)
-        ):
-
-            df.index = df.index.set_levels(
-                df.index.levels[df.index.names.index("timestamp")].shift(1, freq="D"),
-                level="timestamp",
-            )
-
-        # # Special case where timezone shifting may also be necessary.
-        #     df.index = df.index.set_levels(
-        #         df.index.levels[df.index.names.index('timestamp')].shift(-3,freq = 'H'),
-        #         level = 'timestamp')
-
-        return df
-
-    def set_facet_col_row_dimensions(
-        self, facet: bool = True, multi_scenario: list = None
-    ) -> Tuple[int, int]:
-        """Sets facet plot col and row dimensions based on user defined labeles
-
-        Args:
-            facet (bool, optional): Trigger for plotting facet plots.
-                Defaults to True.
-            multi_scenario (list, optional): List of scenarios.
-                Defaults to None.
-
-        Returns:
-            Tuple[int, int]: Facet x,y dimensions.
-        """
-        
-        if not self.xlabels:
-            ncols = 1
-        else:
-            ncols = len(self.xlabels)
-        if not self.ylabels:
-            nrows = 1
-        else:
-            nrows = len(self.ylabels)
-        # If the plot is not a facet plot, grid size should be 1x1
-        if not facet:
-            ncols = 1
-            nrows = 1
-            return ncols, nrows
-        # If no labels were provided or dimensions less than len scenarios use 
-        # Marmot default dimension settings
-        if (
-            not self.xlabels
-            and not self.ylabels
-            or ncols * nrows < len(multi_scenario)
-        ):
-            logger.info(
-                "Dimensions could not be determined from x & y labels - Using Marmot "
-                "default dimensions"
-            )
-            ncols, nrows = self.set_x_y_dimension(len(multi_scenario))
-        return ncols, nrows
-
-    def set_x_y_dimension(self, region_number: int) -> Tuple[int, int]:
-        """Sets X,Y dimension of plots without x,y labels.
-
-        Args:
-            region_number (int): # regions/scenarios
-
-        Returns:
-            Tuple[int, int]: Facet x,y dimensions.
-        """
-        if region_number >= 5:
-            ncols = 3
-            nrows = math.ceil(region_number / 3)
-        if region_number <= 3:
-            ncols = region_number
-            nrows = 1
-        if region_number == 4:
-            ncols = 2
-            nrows = 2
-        return ncols, nrows
-
     def include_net_imports(
         self,
         gen_df: pd.DataFrame,
@@ -561,76 +369,6 @@ class MPlotDataHelper(dict):
         gen_df = self.create_categorical_tech_index(gen_df, axis=1)
         return gen_df
 
-    def capacity_energy_unitconversion(
-        self, df: pd.DataFrame, sum_values: bool = False
-    ) -> dict:
-        """Unitconversion for capacity and energy figures.
-
-        Takes a pd.DataFrame as input and will then determine the max value
-        in the frame.
-
-        If sum_values is True, either rows or columns will be summated before
-        determining max value. The axis is chosen automatically based on where
-        the scenario entries or datetime index is located. If correct axis
-        cannot be determined axis 0 (rows) will be summed.
-        This setting should mainly be set to True when potting stacked bar
-        and area plots.
-
-        Args:
-            df (pd.DataFrame): pandas dataframe
-            sum_values (bool, optional): Sum axis values if True.
-                Should be set to True for stacked bar and area plots.
-                Defaults to False.
-
-        Returns:
-            dict: Dictionary containing divisor and units.
-        """
-        if mconfig.parser("auto_convert_units"):
-            if sum_values:
-                # Check if scenarios are in index sum across columns
-                if isinstance(df.index, pd.MultiIndex) and "Scenario" in df.index.names:
-                    sum_axis = 1
-                # If index datetime sum across columns
-                elif isinstance(df.index, pd.DatetimeIndex):
-                    sum_axis = 1
-                # If any sceanrio is in the index
-                elif any(scen in self.Scenarios for scen in df.index):
-                    sum_axis = 0
-                # If sceanrio is contained as a substring in the index
-                # (only works for equal length lists scenario and index lists)
-                elif [x for x, y in zip(self.Scenarios, df.index) if re.search(x, y)]:
-                    sum_axis = 1
-                elif any(scen in self.Scenarios for scen in df.columns):
-                    sum_axis = 0
-                else:
-                    logger.warning(
-                        "Could not determine axis to sum across, "
-                        "defaulting to axis 0 (rows)"
-                    )
-                    sum_axis = 0
-                max_value = df.abs().sum(axis=sum_axis).max()
-            else:
-                max_value = df.abs().to_numpy().max()
-
-            if max_value < 1000 and max_value > 1:
-                divisor = 1
-                units = "MW"
-            elif max_value < 1:
-                divisor = 0.001
-                units = "kW"
-            elif max_value > 999999.9:
-                divisor = 1000000
-                units = "TW"
-            else:
-                divisor = 1000
-                units = "GW"
-        else:
-            # Disables auto unit conversion, all values in MW
-            divisor = 1
-            units = "MW"
-
-        return {"units": units, "divisor": divisor}
-
     def process_extra_properties(self, extra_properties: List[str], 
         scenario: str,
         zone_input: str,
@@ -639,11 +377,11 @@ class MPlotDataHelper(dict):
     ) -> pd.DataFrame:
         """Processes a list of extra properties and saves them into a single dataframe. 
 
-        Should be used with properties that should be aggregated to a 
+        Use with properties that should be aggregated to a 
         zonal/regional aggregation such as; Load, Demand and Unsereved Energy.
 
         Args:
-            extra_properties (List[str]): list of extra propty names to retrieve from formatted 
+            extra_properties (List[str]): list of extra property names to retrieve from formatted 
                 data file and process
             scenario (str): scenario to pull data from
             zone_input (str): zone to subset by.
@@ -785,65 +523,6 @@ class MPlotDataHelper(dict):
         return df
 
     @staticmethod
-    def set_timestamp_date_range(
-        dfs: Union[pd.DataFrame, List[pd.DataFrame]], start_date: str, end_date: str
-    ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, ...]]:
-        """Sets the timestamp date range based on start_date and end_date strings
-
-        .. versionadded:: 0.10.0
-
-        Takes either a single df or a list of dfs as input.
-        The index must be a pd.DatetimeIndex or a multiindex with level timestamp.
-
-        Args:
-            dfs (Union[pd.DataFrame, List[pd.DataFrame]]): df(s) to set date range for
-            start_date (str): start date
-            end_date (str): end date
-
-        Raises:
-            ValueError: If df.index is not of type type pd.DatetimeIndex or
-                            type pd.MultiIndex with level timestamp.
-
-        Returns:
-            pd.DataFrame or Tuple[pd.DataFrame]: adjusted dataframes
-        """
-
-        logger.info(
-            f"Plotting specific date range: \
-                    {str(start_date)} to {str(end_date)}"
-        )
-
-        df_list = []
-        if isinstance(dfs, list):
-            for df in dfs:
-                if isinstance(df.index, pd.DatetimeIndex):
-                    df = df.loc[start_date:end_date]
-                elif isinstance(df.index, pd.MultiIndex):
-                    df = df.xs(
-                        slice(start_date, end_date), level="timestamp", drop_level=False
-                    )
-                else:
-                    raise ValueError(
-                        "'df.index' must be of type pd.DatetimeIndex or "
-                        "type pd.MultiIndex with level 'timestamp'"
-                    )
-                df_list.append(df)
-            return tuple(df_list)
-        else:
-            if isinstance(dfs.index, pd.DatetimeIndex):
-                df = dfs.loc[start_date:end_date]
-            elif isinstance(dfs.index, pd.MultiIndex):
-                df = dfs.xs(
-                    slice(start_date, end_date), level="timestamp", drop_level=False
-                )
-            else:
-                raise ValueError(
-                    "'df.index' must be of type pd.DatetimeIndex or "
-                    "type pd.MultiIndex with level 'timestamp'"
-                )
-            return df
-
-    @staticmethod
     def year_scenario_grouper(
         df: pd.DataFrame,
         scenario: str,
@@ -914,44 +593,6 @@ class MPlotDataHelper(dict):
         return df.groupby(grouper, **kwargs)
 
     @staticmethod
-    def get_sub_hour_interval_count(df: pd.DataFrame) -> int:
-        """Detects the interval spacing of timeseries data.
-
-        Used to adjust sums of certain variables for sub-hourly data.
-
-        Args:
-            df (pd.DataFrame): pandas dataframe with timestamp in index.
-
-        Returns:
-            int: Number of intervals per 60 minutes.
-        """
-        timestamps = df.index.get_level_values("timestamp").unique()
-        time_delta = timestamps[1] - timestamps[0]
-        # Finds intervals in 60 minute period
-        intervals_per_hour = 60 / (time_delta / np.timedelta64(1, "m"))
-        # If intervals are greater than 1 hour, returns 1
-        return max(1, intervals_per_hour)
-
-    @staticmethod
-    def sort_duration(df: pd.DataFrame, col: str) -> pd.DataFrame:
-        """Converts a dataframe time series into a duration curve.
-
-        Args:
-            df (pd.DataFrame): pandas multiindex dataframe.
-            col (str): Column name by which to sort.
-
-        Returns:
-            pd.DataFrame: Dataframe with values sorted from largest to smallest.
-        """
-        sorted_duration = (
-            df.sort_values(by=col, ascending=False)
-            .reset_index()
-            .drop(columns=["timestamp"])
-        )
-
-        return sorted_duration
-
-    @staticmethod
     def insert_custom_data_columns(
         existing_df: pd.DataFrame, custom_data_file_path: Path
     ) -> pd.DataFrame:
@@ -1004,3 +645,289 @@ class MPlotDataHelper(dict):
             modifed_df.drop("column_position", inplace=True)
 
         return modifed_df
+
+
+
+    #TODO timeseries_modifiers
+    # def adjust_for_leapday(self, df: pd.DataFrame) -> pd.DataFrame:
+    #     """Shifts dataframe ahead by one day.
+        
+    #     Use if a non-leap year time series is modeled with a leap year time index.
+
+    #     Modeled year must be included in the scenario parent directory name.
+    #     Args:
+    #         df (pd.DataFrame): Dataframe to process.
+
+    #     Returns:
+    #         pd.DataFrame: Same dataframe, with time index shifted.
+    #     """
+    #     if (
+    #         "2008" not in self.processed_hdf5_folder
+    #         and "2012" not in self.processed_hdf5_folder
+    #         and df.index.get_level_values("timestamp")[0]
+    #         > dt.datetime(2024, 2, 28, 0, 0)
+    #     ):
+
+    #         df.index = df.index.set_levels(
+    #             df.index.levels[df.index.names.index("timestamp")].shift(1, freq="D"),
+    #             level="timestamp",
+    #         )
+
+    #     # # Special case where timezone shifting may also be necessary.
+    #     #     df.index = df.index.set_levels(
+    #     #         df.index.levels[df.index.names.index('timestamp')].shift(-3,freq = 'H'),
+    #     #         level = 'timestamp')
+
+    #     return df
+    #TODO Move 
+    def merge_new_agg(self, df: pd.DataFrame) -> pd.DataFrame:
+        # TODO Needs fixing
+        """Adds new region aggregation in the plotting step.
+
+        This allows one to create a new aggregation without re-formatting the .h5 file.
+        Args:
+            df (pd.DataFrame): Dataframe to process.
+
+        Returns:
+            pd.DataFrame: Same dataframe, with new aggregation level added.
+        """
+        agg_new = Region_Mapping[["region", self.AGG_BY]]
+        agg_new = agg_new.set_index("region")
+        df = df.merge(agg_new, left_on="region", right_index=True)
+        return df
+
+
+    #TODO Move 
+    def set_facet_col_row_dimensions(
+        self, facet: bool = True, multi_scenario: list = None
+    ) -> Tuple[int, int]:
+        """Sets facet plot col and row dimensions based on user defined labeles
+
+        Args:
+            facet (bool, optional): Trigger for plotting facet plots.
+                Defaults to True.
+            multi_scenario (list, optional): List of scenarios.
+                Defaults to None.
+
+        Returns:
+            Tuple[int, int]: Facet x,y dimensions.
+        """
+        
+        if not xlabels:
+            ncols = 1
+        else:
+            ncols = len(xlabels)
+        if not self.ylabels:
+            nrows = 1
+        else:
+            nrows = len(ylabels)
+        # If the plot is not a facet plot, grid size should be 1x1
+        if not facet:
+            ncols = 1
+            nrows = 1
+            return ncols, nrows
+        # If no labels were provided or dimensions less than len scenarios use 
+        # Marmot default dimension settings
+        if (
+            not xlabels
+            and not ylabels
+            or ncols * nrows < len(multi_scenario)
+        ):
+            logger.info(
+                "Dimensions could not be determined from x & y labels - Using Marmot "
+                "default dimensions"
+            )
+            ncols, nrows = self.set_x_y_dimension(len(multi_scenario))
+        return ncols, nrows
+
+    #TODO Move 
+    def set_x_y_dimension(self, region_number: int) -> Tuple[int, int]:
+        """Sets X,Y dimension of plots without x,y labels.
+
+        Args:
+            region_number (int): # regions/scenarios
+
+        Returns:
+            Tuple[int, int]: Facet x,y dimensions.
+        """
+        if region_number >= 5:
+            ncols = 3
+            nrows = math.ceil(region_number / 3)
+        if region_number <= 3:
+            ncols = region_number
+            nrows = 1
+        if region_number == 4:
+            ncols = 2
+            nrows = 2
+        return ncols, nrows
+
+    #TODO Move 
+    def capacity_energy_unitconversion(
+        self, df: pd.DataFrame, Scenarios: str, sum_values: bool = False
+    ) -> dict:
+        """Unitconversion for capacity and energy figures.
+
+        Takes a pd.DataFrame as input and will then determine the max value
+        in the frame.
+
+        If sum_values is True, either rows or columns will be summated before
+        determining max value. The axis is chosen automatically based on where
+        the scenario entries or datetime index is located. If correct axis
+        cannot be determined axis 0 (rows) will be summed.
+        This setting should mainly be set to True when potting stacked bar
+        and area plots.
+
+        Args:
+            df (pd.DataFrame): pandas dataframe
+            sum_values (bool, optional): Sum axis values if True.
+                Should be set to True for stacked bar and area plots.
+                Defaults to False.
+
+        Returns:
+            dict: Dictionary containing divisor and units.
+        """
+        if mconfig.parser("auto_convert_units"):
+            if sum_values:
+                # Check if scenarios are in index sum across columns
+                if isinstance(df.index, pd.MultiIndex) and "Scenario" in df.index.names:
+                    sum_axis = 1
+                # If index datetime sum across columns
+                elif isinstance(df.index, pd.DatetimeIndex):
+                    sum_axis = 1
+                # If any sceanrio is in the index
+                elif any(scen in Scenarios for scen in df.index):
+                    sum_axis = 0
+                # If sceanrio is contained as a substring in the index
+                # (only works for equal length lists scenario and index lists)
+                elif [x for x, y in zip(Scenarios, df.index) if re.search(x, y)]:
+                    sum_axis = 1
+                elif any(scen in Scenarios for scen in df.columns):
+                    sum_axis = 0
+                else:
+                    logger.warning(
+                        "Could not determine axis to sum across, "
+                        "defaulting to axis 0 (rows)"
+                    )
+                    sum_axis = 0
+                max_value = df.abs().sum(axis=sum_axis).max()
+            else:
+                max_value = df.abs().to_numpy().max()
+
+            if max_value < 1000 and max_value > 1:
+                divisor = 1
+                units = "MW"
+            elif max_value < 1:
+                divisor = 0.001
+                units = "kW"
+            elif max_value > 999999.9:
+                divisor = 1000000
+                units = "TW"
+            else:
+                divisor = 1000
+                units = "GW"
+        else:
+            # Disables auto unit conversion, all values in MW
+            divisor = 1
+            units = "MW"
+
+        return {"units": units, "divisor": divisor}
+
+
+    #TODO timeseries_modifiers
+    # def set_timestamp_date_range(
+    #     dfs: Union[pd.DataFrame, List[pd.DataFrame]], start_date: str, end_date: str
+    # ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, ...]]:
+    #     """Sets the timestamp date range based on start_date and end_date strings
+
+    #     .. versionadded:: 0.10.0
+
+    #     Takes either a single df or a list of dfs as input.
+    #     The index must be a pd.DatetimeIndex or a multiindex with level timestamp.
+
+    #     Args:
+    #         dfs (Union[pd.DataFrame, List[pd.DataFrame]]): df(s) to set date range for
+    #         start_date (str): start date
+    #         end_date (str): end date
+
+    #     Raises:
+    #         ValueError: If df.index is not of type type pd.DatetimeIndex or
+    #                         type pd.MultiIndex with level timestamp.
+
+    #     Returns:
+    #         pd.DataFrame or Tuple[pd.DataFrame]: adjusted dataframes
+    #     """
+
+    #     logger.info(
+    #         f"Plotting specific date range: \
+    #                 {str(start_date)} to {str(end_date)}"
+    #     )
+
+    #     df_list = []
+    #     if isinstance(dfs, list):
+    #         for df in dfs:
+    #             if isinstance(df.index, pd.DatetimeIndex):
+    #                 df = df.loc[start_date:end_date]
+    #             elif isinstance(df.index, pd.MultiIndex):
+    #                 df = df.xs(
+    #                     slice(start_date, end_date), level="timestamp", drop_level=False
+    #                 )
+    #             else:
+    #                 raise ValueError(
+    #                     "'df.index' must be of type pd.DatetimeIndex or "
+    #                     "type pd.MultiIndex with level 'timestamp'"
+    #                 )
+    #             df_list.append(df)
+    #         return tuple(df_list)
+    #     else:
+    #         if isinstance(dfs.index, pd.DatetimeIndex):
+    #             df = dfs.loc[start_date:end_date]
+    #         elif isinstance(dfs.index, pd.MultiIndex):
+    #             df = dfs.xs(
+    #                 slice(start_date, end_date), level="timestamp", drop_level=False
+    #             )
+    #         else:
+    #             raise ValueError(
+    #                 "'df.index' must be of type pd.DatetimeIndex or "
+    #                 "type pd.MultiIndex with level 'timestamp'"
+    #             )
+    #         return df
+
+
+    #TODO timeseries_modifiers
+    # def get_sub_hour_interval_count(df: pd.DataFrame) -> int:
+    #     """Detects the interval spacing of timeseries data.
+
+    #     Used to adjust sums of certain variables for sub-hourly data.
+
+    #     Args:
+    #         df (pd.DataFrame): pandas dataframe with timestamp in index.
+
+    #     Returns:
+    #         int: Number of intervals per 60 minutes.
+    #     """
+    #     timestamps = df.index.get_level_values("timestamp").unique()
+    #     time_delta = timestamps[1] - timestamps[0]
+    #     # Finds intervals in 60 minute period
+    #     intervals_per_hour = 60 / (time_delta / np.timedelta64(1, "m"))
+    #     # If intervals are greater than 1 hour, returns 1
+    #     return max(1, intervals_per_hour)
+
+    # @staticmethod
+    # def sort_duration(df: pd.DataFrame, col: str) -> pd.DataFrame:
+    #     """Converts a dataframe time series into a duration curve.
+
+    #     Args:
+    #         df (pd.DataFrame): pandas multiindex dataframe.
+    #         col (str): Column name by which to sort.
+
+    #     Returns:
+    #         pd.DataFrame: Dataframe with values sorted from largest to smallest.
+    #     """
+    #     sorted_duration = (
+    #         df.sort_values(by=col, ascending=False)
+    #         .reset_index()
+    #         .drop(columns=["timestamp"])
+    #     )
+
+    #     return sorted_duration
+

--- a/marmot/plottingmodules/plotutils/plot_data_helper.py
+++ b/marmot/plottingmodules/plotutils/plot_data_helper.py
@@ -21,7 +21,7 @@ from marmot.plottingmodules.plotutils.timeseries_modifiers import adjust_for_lea
 
 logger = logging.getLogger("plotter." + __name__)
 shift_leapday: bool = mconfig.parser("shift_leapday")
-curtailment_prop = mconfig.parser("plot_data", "curtailment_property")
+curtailment_prop: str = mconfig.parser("plot_data", "curtailment_property")
 
 @dataclass
 class GenCategories:

--- a/marmot/plottingmodules/plotutils/styles.py
+++ b/marmot/plottingmodules/plotutils/styles.py
@@ -1,0 +1,74 @@
+
+from dataclasses import dataclass, field, asdict
+from typing import List
+import pandas as pd
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+
+
+@dataclass
+class ColorList():
+
+    colors: List[str] = field(
+        default_factory=lambda: [
+            "#396AB1",
+            "#CC2529",
+            "#3E9651",
+            "#ff7f00",
+            "#6B4C9A",
+            "#922428",
+            "#cab2d6",
+            "#6a3d9a",
+            "#fb9a99",
+            "#b15928",]
+    )
+
+@dataclass
+class PlotMarkers():
+
+    markers: List[str] = field(
+        default_factory=lambda: [
+            "^", 
+            "*", 
+            "o", 
+            "D", 
+            "x", 
+            "<", 
+            "P", 
+            "H", 
+            "8", 
+            "+"]
+    )
+
+@dataclass
+class GeneratorColorDict():
+
+    color_dict: dict
+
+    @classmethod
+    def set_colors_from_df(cls, color_df: pd.DataFrame) -> "GeneratorColorDict":
+
+        color_dict = color_df.rename(
+            columns={
+                color_df.columns[0]: "Generator",
+                color_df.columns[1]: "Colour",
+            }
+        )
+        color_dict["Generator"] = color_dict["Generator"].str.strip()
+        color_dict["Colour"] = color_dict["Colour"].str.strip()
+        color_dict = (
+            color_dict[["Generator", "Colour"]]
+            .set_index("Generator")
+            .to_dict()["Colour"]
+        )
+        return cls(color_dict)
+
+    @classmethod
+    def set_random_colors(cls, generator_list: list) -> "GeneratorColorDict":
+
+        cmap = plt.cm.get_cmap(lut=len(generator_list))
+        colors = []
+        for i in range(cmap.N):
+            colors.append(mcolors.rgb2hex(cmap(i)))
+        color_dict = dict(zip(generator_list, colors))
+        return cls(color_dict)

--- a/marmot/plottingmodules/plotutils/styles.py
+++ b/marmot/plottingmodules/plotutils/styles.py
@@ -1,5 +1,9 @@
+"""Classes containing color styles and markers for plotting
 
-from dataclasses import dataclass, field, asdict
+@author: Daniel Levie
+"""
+
+from dataclasses import dataclass, field
 from typing import List
 import pandas as pd
 import matplotlib.colors as mcolors
@@ -8,7 +12,10 @@ import matplotlib.pyplot as plt
 
 @dataclass
 class ColorList():
+    """List of colors to apply to plots.
 
+    Generally used with non generator plots.
+    """
     colors: List[str] = field(
         default_factory=lambda: [
             "#396AB1",
@@ -25,7 +32,8 @@ class ColorList():
 
 @dataclass
 class PlotMarkers():
-
+    """List of plot markers to use in certain plots.
+    """
     markers: List[str] = field(
         default_factory=lambda: [
             "^", 
@@ -42,12 +50,37 @@ class PlotMarkers():
 
 @dataclass
 class GeneratorColorDict():
+    """Dictionary of gen names to colors for generation plots.
+
+    The dictionary is usually set with the colour_dictionary.csv using 
+    the set_colors_from_df method. The file should have the following
+    format:
+
+        https://nrel.github.io/Marmot/references/input-files/mapping-folder/colour_dictionary.html
+
+    Random colors can also be set with the set_random_colors method or assigned
+    manually directly to the color_dict attribute.
+
+    Args:
+        Dictionary of generator names to colors.
+    """
 
     color_dict: dict
 
     @classmethod
     def set_colors_from_df(cls, color_df: pd.DataFrame) -> "GeneratorColorDict":
+        """Sets colors from a dataframe.
 
+        The dataframe should have the following format:
+
+            https://nrel.github.io/Marmot/references/input-files/mapping-folder/colour_dictionary.html
+
+        Args:
+            color_df (pd.DataFrame): DataFrame with Generator and Color column
+
+        Returns:
+            GeneratorColorDict: Instance of class 
+        """
         color_dict = color_df.rename(
             columns={
                 color_df.columns[0]: "Generator",
@@ -65,7 +98,14 @@ class GeneratorColorDict():
 
     @classmethod
     def set_random_colors(cls, generator_list: list) -> "GeneratorColorDict":
+        """Sets random colors, given a list of names/technologies
 
+        Args:
+            generator_list (list): List of generator names. 
+
+        Returns:
+            GeneratorColorDict: Instance of class 
+        """
         cmap = plt.cm.get_cmap(lut=len(generator_list))
         colors = []
         for i in range(cmap.N):

--- a/marmot/plottingmodules/plotutils/timeseries_modifiers.py
+++ b/marmot/plottingmodules/plotutils/timeseries_modifiers.py
@@ -1,0 +1,128 @@
+
+import logging
+import datetime as dt
+from typing import Tuple, Union, List
+
+import numpy as np
+import pandas as pd
+logger = logging.getLogger("plotter." + __name__)
+
+
+def set_timestamp_date_range(
+    dfs: Union[pd.DataFrame, List[pd.DataFrame]], start_date: str, end_date: str
+) -> Union[pd.DataFrame, Tuple[pd.DataFrame, ...]]:
+    """Sets the timestamp date range based on start_date and end_date strings
+
+    .. versionadded:: 0.10.0
+
+    Takes either a single df or a list of dfs as input.
+    The index must be a pd.DatetimeIndex or a multiindex with level timestamp.
+
+    Args:
+        dfs (Union[pd.DataFrame, List[pd.DataFrame]]): df(s) to set date range for
+        start_date (str): start date
+        end_date (str): end date
+
+    Raises:
+        ValueError: If df.index is not of type type pd.DatetimeIndex or
+                        type pd.MultiIndex with level timestamp.
+
+    Returns:
+        pd.DataFrame or Tuple[pd.DataFrame]: adjusted dataframes
+    """
+
+    logger.info(
+        f"Plotting specific date range: \
+                {str(start_date)} to {str(end_date)}"
+    )
+
+    df_list = []
+    if isinstance(dfs, list):
+        for df in dfs:
+            if isinstance(df.index, pd.DatetimeIndex):
+                df = df.loc[start_date:end_date]
+            elif isinstance(df.index, pd.MultiIndex):
+                df = df.xs(
+                    slice(start_date, end_date), level="timestamp", drop_level=False
+                )
+            else:
+                raise ValueError(
+                    "'df.index' must be of type pd.DatetimeIndex or "
+                    "type pd.MultiIndex with level 'timestamp'"
+                )
+            df_list.append(df)
+        return tuple(df_list)
+    else:
+        if isinstance(dfs.index, pd.DatetimeIndex):
+            df = dfs.loc[start_date:end_date]
+        elif isinstance(dfs.index, pd.MultiIndex):
+            df = dfs.xs(
+                slice(start_date, end_date), level="timestamp", drop_level=False
+            )
+        else:
+            raise ValueError(
+                "'df.index' must be of type pd.DatetimeIndex or "
+                "type pd.MultiIndex with level 'timestamp'"
+            )
+        return df
+
+def get_sub_hour_interval_count(df: pd.DataFrame) -> int:
+    """Detects the interval spacing of timeseries data.
+
+    Used to adjust sums of certain variables for sub-hourly data.
+
+    Args:
+        df (pd.DataFrame): pandas dataframe with timestamp in index.
+
+    Returns:
+        int: Number of intervals per 60 minutes.
+    """
+    timestamps = df.index.get_level_values("timestamp").unique()
+    time_delta = timestamps[1] - timestamps[0]
+    # Finds intervals in 60 minute period
+    intervals_per_hour = 60 / (time_delta / np.timedelta64(1, "m"))
+    # If intervals are greater than 1 hour, returns 1
+    return max(1, intervals_per_hour)
+
+def adjust_for_leapday(self, df: pd.DataFrame) -> pd.DataFrame:
+    """Shifts dataframe ahead by one day.
+    
+    Use if a non-leap year time series is modeled with a leap year time index.
+
+    Modeled year must be included in the scenario parent directory name.
+    Args:
+        df (pd.DataFrame): Dataframe to process.
+
+    Returns:
+        pd.DataFrame: Same dataframe, with time index shifted.
+    """
+    if (
+        "2008" not in self.processed_hdf5_folder
+        and "2012" not in self.processed_hdf5_folder
+        and df.index.get_level_values("timestamp")[0]
+        > dt.datetime(2024, 2, 28, 0, 0)
+    ):
+
+        df.index = df.index.set_levels(
+            df.index.levels[df.index.names.index("timestamp")].shift(1, freq="D"),
+            level="timestamp",
+        )
+        return df
+
+def sort_duration(df: pd.DataFrame, col: str) -> pd.DataFrame:
+    """Converts a dataframe time series into a duration curve.
+
+    Args:
+        df (pd.DataFrame): pandas multiindex dataframe.
+        col (str): Column name by which to sort.
+
+    Returns:
+        pd.DataFrame: Dataframe with values sorted from largest to smallest.
+    """
+    sorted_duration = (
+        df.sort_values(by=col, ascending=False)
+        .reset_index()
+        .drop(columns=["timestamp"])
+    )
+
+    return sorted_duration

--- a/marmot/plottingmodules/plotutils/timeseries_modifiers.py
+++ b/marmot/plottingmodules/plotutils/timeseries_modifiers.py
@@ -1,3 +1,7 @@
+"""Collection of functions which modify or infer information from timeseries 
+
+@author: Daniel Levie
+"""
 
 import logging
 import datetime as dt
@@ -12,8 +16,6 @@ def set_timestamp_date_range(
     dfs: Union[pd.DataFrame, List[pd.DataFrame]], start_date: str, end_date: str
 ) -> Union[pd.DataFrame, Tuple[pd.DataFrame, ...]]:
     """Sets the timestamp date range based on start_date and end_date strings
-
-    .. versionadded:: 0.10.0
 
     Takes either a single df or a list of dfs as input.
     The index must be a pd.DatetimeIndex or a multiindex with level timestamp.

--- a/marmot/plottingmodules/prices.py
+++ b/marmot/plottingmodules/prices.py
@@ -12,10 +12,12 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from pathlib import Path
+from typing import List
 import marmot.utils.mconfig as mconfig
 
+from marmot.plottingmodules.plotutils.styles import ColorList
 from marmot.plottingmodules.plotutils.plot_library import SetupSubplot
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     DataSavedInModule,
@@ -26,28 +28,41 @@ logger = logging.getLogger("plotter." + __name__)
 plot_data_settings = mconfig.parser("plot_data")
 
 
-class Prices(MPlotDataHelper):
+class Prices(PlotDataStoreAndProcessor):
     """Locational price analysis plots.
 
     The price.py module contains methods that are
     related to grid prices at regions, zones, nodes etc.
 
-    Prices inherits from the MPlotDataHelper class to assist
+    Prices inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args, 
+        color_list: list = ColorList().colors,
+        ylabels: List[str] = None,
+        xlabels: List[str] = None,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        self.color_list = color_list
+        self.ylabels = ylabels
+        self.xlabels = xlabels
 
     def pdc_all_regions(
         self,
@@ -85,7 +100,7 @@ class Prices(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, f"{agg}_Price", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -216,7 +231,7 @@ class Prices(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, f"{agg}_Price", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -341,7 +356,7 @@ class Prices(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, f"{agg}_Price", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -457,7 +472,7 @@ class Prices(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, f"{agg}_Price", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -612,7 +627,7 @@ class Prices(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "node_Price", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -777,7 +792,7 @@ class Prices(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "node_Price", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 

--- a/marmot/plottingmodules/prices.py
+++ b/marmot/plottingmodules/prices.py
@@ -26,7 +26,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 
 
 class Prices(PlotDataStoreAndProcessor):

--- a/marmot/plottingmodules/production_cost.py
+++ b/marmot/plottingmodules/production_cost.py
@@ -10,10 +10,12 @@ Plots can be broken down by cost categories, generator types etc.
 import logging
 import pandas as pd
 from pathlib import Path
+from typing import List
 
 import marmot.utils.mconfig as mconfig
+from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -23,28 +25,42 @@ plot_data_settings = mconfig.parser("plot_data")
 logger = logging.getLogger("plotter." + __name__)
 
 
-class SystemCosts(MPlotDataHelper):
+class SystemCosts(PlotDataStoreAndProcessor):
     """System operating cost plots.
 
     The production_cost.py module contains methods that are
     related related to the cost of operating the power system.
 
-    SystemCosts inherits from the MPlotDataHelper class to assist
+    SystemCosts inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args,
+        marmot_color_dict: dict = None,
+        custom_xticklabels: List[str] = None,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        if marmot_color_dict is None:
+            self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
+        else:
+            self.marmot_color_dict = marmot_color_dict
+        self.custom_xticklabels = custom_xticklabels
 
     def prod_cost(
         self,
@@ -90,7 +106,7 @@ class SystemCosts(MPlotDataHelper):
             (True, "generator_Installed_Capacity", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -259,7 +275,7 @@ class SystemCosts(MPlotDataHelper):
             (False, f"{agg}_Cost_Unserved_Energy", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -446,7 +462,7 @@ class SystemCosts(MPlotDataHelper):
             (False, "generator_Emissions_Cost", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -635,7 +651,7 @@ class SystemCosts(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "generator_Total_Generation_Cost", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -715,7 +731,7 @@ class SystemCosts(MPlotDataHelper):
 
             mplt.barplot(
                 total_systems_cost_out,
-                color=self.PLEXOS_color_dict,
+                color=self.marmot_color_dict,
                 stacked=True,
                 custom_tick_labels=tick_labels,
             )
@@ -777,7 +793,7 @@ class SystemCosts(MPlotDataHelper):
             (False, f"{agg}_Cost_Unserved_Energy", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -925,7 +941,7 @@ class SystemCosts(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "generator_Total_Generation_Cost", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
         # Checks if all data required by plot is available, if 1 in list required data is missing
@@ -1003,7 +1019,7 @@ class SystemCosts(MPlotDataHelper):
             fig, ax = mplt.get_figure()
 
             mplt.barplot(
-                total_systems_cost_out, color=self.PLEXOS_color_dict, stacked=True
+                total_systems_cost_out, color=self.marmot_color_dict, stacked=True
             )
 
             ax.axhline(y=0)
@@ -1066,7 +1082,7 @@ class SystemCosts(MPlotDataHelper):
             (False, "generator_Emissions_Cost", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 

--- a/marmot/plottingmodules/production_cost.py
+++ b/marmot/plottingmodules/production_cost.py
@@ -22,7 +22,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingZoneData,
 )
 
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 logger = logging.getLogger("plotter." + __name__)
 
 

--- a/marmot/plottingmodules/production_cost.py
+++ b/marmot/plottingmodules/production_cost.py
@@ -15,7 +15,8 @@ from typing import List
 import marmot.utils.mconfig as mconfig
 from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor, GenCategories
+from marmot.plottingmodules.plotutils.timeseries_modifiers import set_timestamp_date_range
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -38,21 +39,29 @@ class SystemCosts(PlotDataStoreAndProcessor):
     def __init__(self, 
         Zones: List[str], 
         Scenarios: List[str], 
-        *args,
+        AGG_BY: str,
+        ordered_gen: List[str],
+        marmot_solutions_folder: Path,
         marmot_color_dict: dict = None,
         custom_xticklabels: List[str] = None,
         **kwargs):
         """
         Args:
-            *args
-                Minimum required parameters passed to the PlotDataStoreAndProcessor 
-                class.
-            **kwargs
-                These parameters will be passed to the PlotDataStoreAndProcessor 
-                class.
+            Zones (List[str]): List of regions/zones to plot.
+            Scenarios (List[str]): List of scenarios to plot.
+            AGG_BY (str): Informs region type to aggregate by when creating plots.
+            ordered_gen (List[str]): Ordered list of generator technologies to plot,
+                order defines the generator technology position in stacked bar and area plots.
+            marmot_solutions_folder (Path): Directory containing Marmot solution outputs.
+            marmot_color_dict (dict, optional): Dictionary of colors to use for 
+                generation technologies.
+                Defaults to None.
+            custom_xticklabels (List[str], optional): List of custom x labels to 
+                apply to barplots. Values will overwite existing ones. 
+                Defaults to None.
         """
-        # Instantiation of MPlotHelperFunctions
-        super().__init__(*args, **kwargs)
+        # Instantiation of PlotDataStoreAndProcessor
+        super().__init__(AGG_BY, ordered_gen, marmot_solutions_folder, **kwargs)
 
         self.Zones = Zones
         self.Scenarios = Scenarios
@@ -316,7 +325,7 @@ class SystemCosts(PlotDataStoreAndProcessor):
                 )
 
                 if pd.notna(start_date_range):
-                    gen_cost, cost_unserved_energy = self.set_timestamp_date_range(
+                    gen_cost, cost_unserved_energy = set_timestamp_date_range(
                         [gen_cost, cost_unserved_energy],
                         start_date_range,
                         end_date_range,
@@ -511,7 +520,7 @@ class SystemCosts(PlotDataStoreAndProcessor):
                 )
 
                 if pd.notna(start_date_range):
-                    detailed_gen_cost = self.set_timestamp_date_range(
+                    detailed_gen_cost = set_timestamp_date_range(
                         detailed_gen_cost, start_date_range, end_date_range
                     )
                     if detailed_gen_cost.empty is True:
@@ -678,7 +687,7 @@ class SystemCosts(PlotDataStoreAndProcessor):
                 gen_cost = self.df_process_gen_inputs(gen_cost)
 
                 if pd.notna(start_date_range):
-                    gen_cost = self.set_timestamp_date_range(
+                    gen_cost = set_timestamp_date_range(
                         gen_cost, start_date_range, end_date_range
                     )
                     if gen_cost.empty is True:
@@ -834,7 +843,7 @@ class SystemCosts(PlotDataStoreAndProcessor):
                 )
 
                 if pd.notna(start_date_range):
-                    gen_cost, cost_unserved_energy = self.set_timestamp_date_range(
+                    gen_cost, cost_unserved_energy = set_timestamp_date_range(
                         [gen_cost, cost_unserved_energy],
                         start_date_range,
                         end_date_range,
@@ -966,7 +975,7 @@ class SystemCosts(PlotDataStoreAndProcessor):
                 gen_cost = self.df_process_gen_inputs(gen_cost)
 
                 if pd.notna(start_date_range):
-                    gen_cost = self.set_timestamp_date_range(
+                    gen_cost = set_timestamp_date_range(
                         gen_cost, start_date_range, end_date_range
                     )
                     if gen_cost.empty is True:
@@ -1131,7 +1140,7 @@ class SystemCosts(PlotDataStoreAndProcessor):
                 )
 
                 if pd.notna(start_date_range):
-                    detailed_gen_cost = self.set_timestamp_date_range(
+                    detailed_gen_cost = set_timestamp_date_range(
                         detailed_gen_cost, start_date_range, end_date_range
                     )
                     if detailed_gen_cost.empty is True:

--- a/marmot/plottingmodules/ramping.py
+++ b/marmot/plottingmodules/ramping.py
@@ -8,11 +8,11 @@ This module creates bar plot of the total volume of generator starts in MW,GW,et
 
 import logging
 import pandas as pd
-
+from typing import List
 import marmot.utils.mconfig as mconfig
-
+from marmot.plottingmodules.plotutils.styles import ColorList
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -23,28 +23,37 @@ logger = logging.getLogger("plotter." + __name__)
 plot_data_settings = mconfig.parser("plot_data")
 
 
-class Ramping(MPlotDataHelper):
+class Ramping(PlotDataStoreAndProcessor):
     """Generator start and ramping plots.
 
     The ramping.py module contains methods that are
     related to the ramp periods of generators.
 
-    Ramping inherits from the MPlotDataHelper class to assist
+    Ramping inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args,
+        color_list: list = ColorList().colors,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        self.color_list = color_list
 
     def capacity_started(
         self,
@@ -86,8 +95,8 @@ class Ramping(MPlotDataHelper):
             (True, "generator_Installed_Capacity", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate
-        # MPlotDataHelper dictionary with all required properties,
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate
+        # PlotDataStoreAndProcessor dictionary with all required properties,
         # returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -240,7 +249,7 @@ class Ramping(MPlotDataHelper):
             (True, "generator_Installed_Capacity", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -397,8 +406,8 @@ class Ramping(MPlotDataHelper):
             (True, "generator_Generation", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate
-        # MPlotDataHelper dictionary with all required properties,
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate
+        # PlotDataStoreAndProcessor dictionary with all required properties,
         # returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 

--- a/marmot/plottingmodules/ramping.py
+++ b/marmot/plottingmodules/ramping.py
@@ -23,7 +23,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 
 
 class Ramping(PlotDataStoreAndProcessor):

--- a/marmot/plottingmodules/reserves.py
+++ b/marmot/plottingmodules/reserves.py
@@ -12,11 +12,12 @@ import numpy as np
 import pandas as pd
 import datetime as dt
 import matplotlib.pyplot as plt
-
+from typing import List
 import marmot.utils.mconfig as mconfig
 
+from marmot.plottingmodules.plotutils.styles import ColorList, GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import SetupSubplot, PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -26,29 +27,49 @@ logger = logging.getLogger("plotter." + __name__)
 plot_data_settings = mconfig.parser("plot_data")
 
 
-class Reserves(MPlotDataHelper):
+class Reserves(PlotDataStoreAndProcessor):
     """Generator and system reserve plots.
 
     The reserves.py module contains methods that are
     related to reserve provision and shortage.
 
-    Reserves inherits from the MPlotDataHelper class to assist
+    Reserves inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args,
+        marmot_color_dict: dict = None,
+        ylabels: List[str] = None,
+        xlabels: List[str] = None,
+        custom_xticklabels: List[str] = None,
+        color_list: list = ColorList().colors,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
 
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        if marmot_color_dict is None:
+            self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
+        else:
+            self.marmot_color_dict = marmot_color_dict
+        self.ylabels = ylabels
+        self.xlabels = xlabels
+        self.custom_xticklabels = custom_xticklabels
+        self.color_list = color_list
+        
     def reserve_gen_timeseries(
         self,
         prop: str = None,
@@ -110,7 +131,7 @@ class Reserves(MPlotDataHelper):
             (True, f"reserves_generators_Provision{data_resolution}", self.Scenarios)
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -206,7 +227,7 @@ class Reserves(MPlotDataHelper):
 
                 mplt.stackplot(
                     reserve_provision_timeseries,
-                    color_dict=self.PLEXOS_color_dict,
+                    color_dict=self.marmot_color_dict,
                     labels=reserve_provision_timeseries.columns,
                     sub_pos=n,
                 )
@@ -272,7 +293,7 @@ class Reserves(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "reserves_generators_Provision", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -354,7 +375,7 @@ class Reserves(MPlotDataHelper):
 
             mplt.barplot(
                 total_reserves_out,
-                color=self.PLEXOS_color_dict,
+                color=self.marmot_color_dict,
                 stacked=True,
                 custom_tick_labels=tick_labels,
             )
@@ -455,7 +476,7 @@ class Reserves(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, f"reserve_{data_set}", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -636,7 +657,7 @@ class Reserves(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, f"reserve_Shortage{data_resolution}", Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 

--- a/marmot/plottingmodules/reserves.py
+++ b/marmot/plottingmodules/reserves.py
@@ -27,7 +27,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 
 
 class Reserves(PlotDataStoreAndProcessor):

--- a/marmot/plottingmodules/sensitivities.py
+++ b/marmot/plottingmodules/sensitivities.py
@@ -22,8 +22,8 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
-
+plot_data_settings: dict = mconfig.parser("plot_data")
+curtailment_prop: str = mconfig.parser("plot_data", "curtailment_property")
 
 class Sensitivities(PlotDataStoreAndProcessor):
     """System sensitivity plots
@@ -70,7 +70,7 @@ class Sensitivities(PlotDataStoreAndProcessor):
         else:
             self.marmot_color_dict = marmot_color_dict
         self.Region_Mapping = Region_Mapping
-        self.curtailment_prop = mconfig.parser("plot_data", "curtailment_property")
+
 
     def _process_ts(self, df, zone_input):
         oz = df.xs(zone_input, level=self.AGG_BY)
@@ -133,7 +133,7 @@ class Sensitivities(PlotDataStoreAndProcessor):
         # scenarios must be a list.
         properties = [
             (True, "generator_Generation", self.Scenario_Diff),
-            (True, f"generator_{self.curtailment_prop}", self.Scenario_Diff),
+            (True, f"generator_{curtailment_prop}", self.Scenario_Diff),
             (True, "region_Net_Interchange", self.Scenario_Diff),
         ]
 
@@ -176,10 +176,10 @@ class Sensitivities(PlotDataStoreAndProcessor):
         scen_CC = scen.xs("Gas-CC", level="tech")
 
         curt_bc = adjust_for_leapday(
-            self[f"generator_{self.curtailment_prop}"].get(self.Scenario_Diff[0])
+            self[f"generator_{curtailment_prop}"].get(self.Scenario_Diff[0])
         )
         curt_scen = adjust_for_leapday(
-            self[f"generator_{self.curtailment_prop}"].get(self.Scenario_Diff[1])
+            self[f"generator_{curtailment_prop}"].get(self.Scenario_Diff[1])
         )
         curt_diff_all = curt_scen - curt_bc
 

--- a/marmot/plottingmodules/storage.py
+++ b/marmot/plottingmodules/storage.py
@@ -8,11 +8,13 @@ import logging
 import pandas as pd
 import matplotlib.pyplot as plt
 from typing import List
+from pathlib import Path
 
 import marmot.utils.mconfig as mconfig
 from marmot.plottingmodules.plotutils.styles import ColorList
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor, GenCategories, set_x_y_dimension
+from marmot.plottingmodules.plotutils.timeseries_modifiers import set_timestamp_date_range, adjust_for_leapday, sort_duration
 from marmot.plottingmodules.plotutils.plot_exceptions import (MissingInputData, DataSavedInModule,
     MissingZoneData)
 from marmot.plottingmodules.plotutils.plot_library import SetupSubplot
@@ -34,20 +36,24 @@ class Storage(PlotDataStoreAndProcessor):
     def __init__(self, 
         Zones: List[str], 
         Scenarios: List[str], 
-        *args,
+        AGG_BY: str,
+        ordered_gen: List[str],
+        marmot_solutions_folder: Path,
         color_list: list = ColorList().colors,
         **kwargs):
         """
         Args:
-            *args
-                Minimum required parameters passed to the PlotDataStoreAndProcessor 
-                class.
-            **kwargs
-                These parameters will be passed to the PlotDataStoreAndProcessor 
-                class.
+            Zones (List[str]): List of regions/zones to plot.
+            Scenarios (List[str]): List of scenarios to plot.
+            AGG_BY (str): Informs region type to aggregate by when creating plots.
+            ordered_gen (List[str]): Ordered list of generator technologies to plot,
+                order defines the generator technology position in stacked bar and area plots.
+            marmot_solutions_folder (Path): Directory containing Marmot solution outputs.
+            color_list (list, optional): List of colors to apply to non-gen plots.
+                Defaults to ColorList().colors.
         """
-        # Instantiation of MPlotHelperFunctions
-        super().__init__(*args, **kwargs)
+        # Instantiation of PlotDataStoreAndProcessor
+        super().__init__(AGG_BY, ordered_gen, marmot_solutions_folder, **kwargs)
 
         self.Zones = Zones
         self.Scenarios = Scenarios
@@ -147,7 +153,7 @@ class Storage(PlotDataStoreAndProcessor):
                 use.columns = [scenario]
 
                 if pd.notna(start_date_range):
-                    storage_volume, max_volume, use = self.set_timestamp_date_range(
+                    storage_volume, max_volume, use = set_timestamp_date_range(
                         [storage_volume, max_volume, use],
                         start_date_range,
                         end_date_range,
@@ -289,7 +295,7 @@ class Storage(PlotDataStoreAndProcessor):
         logger.info(f'Plotting only batteries specified in Marmot_plot_select.csv')
         logger.info(select_bats)
 
-        xdim, ydim = self.set_x_y_dimension(len(select_bats))
+        xdim, ydim = set_x_y_dimension(len(select_bats))
         mplt = PlotLibrary(ydim, xdim, squeeze=False,
                             ravel_axs=True, sharey=True)
         fig, axs = mplt.get_figure()
@@ -312,10 +318,10 @@ class Storage(PlotDataStoreAndProcessor):
                 gen = gen.rename(columns={"values": scenario})
 
                 if shift_leapday:
-                    gen = self.adjust_for_leapday(gen)
+                    gen = adjust_for_leapday(gen)
 
                 if pd.notna(start_date_range):
-                    gen = self.set_timestamp_date_range(
+                    gen = set_timestamp_date_range(
                         gen, start_date_range, end_date_range
                     )
                     if gen.empty is True:
@@ -341,7 +347,7 @@ class Storage(PlotDataStoreAndProcessor):
             # Only convert on first lines
             if n == 0:
                 unitconversion = self.capacity_energy_unitconversion(
-                    gen_out, sum_values=False
+                    gen_out, self.Scenarios, sum_values=False
                 )
             gen_out = (
                 gen_out / unitconversion["divisor"]
@@ -351,7 +357,7 @@ class Storage(PlotDataStoreAndProcessor):
             # Plot line flow
             for column in gen_out:
                 if duration_curve:
-                    gen_single = self.sort_duration(gen_out, column)
+                    gen_single = sort_duration(gen_out, column)
                 else:
                     gen_single = gen_out
                 legend_label = f"{column}"

--- a/marmot/plottingmodules/storage.py
+++ b/marmot/plottingmodules/storage.py
@@ -20,7 +20,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (MissingInputData, 
 from marmot.plottingmodules.plotutils.plot_library import SetupSubplot
 
 logger = logging.getLogger('plotter.'+__name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 shift_leapday : bool = mconfig.parser("shift_leapday")
 
 class Storage(PlotDataStoreAndProcessor):

--- a/marmot/plottingmodules/storage.py
+++ b/marmot/plottingmodules/storage.py
@@ -7,41 +7,51 @@ This module creates energy storage plots.
 import logging
 import pandas as pd
 import matplotlib.pyplot as plt
+from typing import List
 
 import marmot.utils.mconfig as mconfig
-from marmot.metamanagers.read_metadata import MetaData
+from marmot.plottingmodules.plotutils.styles import ColorList
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (MissingInputData, DataSavedInModule,
-            UnderDevelopment, InputSheetError, MissingMetaData, UnsupportedAggregation, MissingZoneData)
+    MissingZoneData)
 from marmot.plottingmodules.plotutils.plot_library import SetupSubplot
 
 logger = logging.getLogger('plotter.'+__name__)
 plot_data_settings = mconfig.parser("plot_data")
 shift_leapday : bool = mconfig.parser("shift_leapday")
 
-class Storage(MPlotDataHelper):
+class Storage(PlotDataStoreAndProcessor):
     """Energy storage plots.
 
     The storage.py module contains methods that are
     related to storage devices.
 
-    Storage inherits from the MPlotDataHelper class to assist
+    Storage inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args,
+        color_list: list = ColorList().colors,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        self.color_list = color_list
 
     def storage_volume(
         self,
@@ -82,7 +92,7 @@ class Storage(MPlotDataHelper):
             (True, "storage_Max_Volume", [self.Scenarios[0]]),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -267,7 +277,7 @@ class Storage(MPlotDataHelper):
         properties = [
             (True, f"batterie_{var}", self.Scenarios),
         ]
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 

--- a/marmot/plottingmodules/thermal_cap_reserve.py
+++ b/marmot/plottingmodules/thermal_cap_reserve.py
@@ -11,12 +11,15 @@ import logging
 import pandas as pd
 import matplotlib.pyplot as plt
 from typing import List
+from pathlib import Path
+
 
 import marmot.utils.mconfig as mconfig
 
 from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor, GenCategories, set_facet_col_row_dimensions
+from marmot.plottingmodules.plotutils.timeseries_modifiers import set_timestamp_date_range, adjust_for_leapday
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -40,25 +43,39 @@ class ThermalReserve(PlotDataStoreAndProcessor):
     def __init__(self, 
         Zones: List[str], 
         Scenarios: List[str], 
-        *args,
+        AGG_BY: str,
+        ordered_gen: List[str],
+        marmot_solutions_folder: Path,
+        gen_categories: GenCategories = GenCategories(),
         marmot_color_dict: dict = None,
         ylabels: List[str] = None,
         xlabels: List[str] = None,
         **kwargs):
         """
         Args:
-            *args
-                Minimum required parameters passed to the PlotDataStoreAndProcessor 
-                class.
-            **kwargs
-                These parameters will be passed to the PlotDataStoreAndProcessor 
-                class.
+            Zones (List[str]): List of regions/zones to plot.
+            Scenarios (List[str]): List of scenarios to plot.
+            AGG_BY (str): Informs region type to aggregate by when creating plots.
+            ordered_gen (List[str]): Ordered list of generator technologies to plot,
+                order defines the generator technology position in stacked bar and area plots.
+            marmot_solutions_folder (Path): Directory containing Marmot solution outputs.
+            gen_categories (GenCategories): Instance of GenCategories class, groups generator technologies 
+                into defined categories.
+                Deafults to GenCategories.
+            marmot_color_dict (dict, optional): Dictionary of colors to use for 
+                generation technologies.
+                Defaults to None.
+            ylabels (List[str], optional): y-axis labels for facet plots.
+                Defaults to None.
+            xlabels (List[str], optional): x-axis labels for facet plots.
+                Defaults to None.        
         """
-        # Instantiation of MPlotHelperFunctions
-        super().__init__(*args, **kwargs)
+        # Instantiation of PlotDataStoreAndProcessor
+        super().__init__(AGG_BY, ordered_gen, marmot_solutions_folder, **kwargs)
 
         self.Zones = Zones
         self.Scenarios = Scenarios
+        self.gen_categories = gen_categories
         if marmot_color_dict is None:
             self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
         else:
@@ -114,7 +131,7 @@ class ThermalReserve(PlotDataStoreAndProcessor):
             logger.info(f"Zone = {zone_input}")
 
             # sets up x, y dimensions of plot
-            ncols, nrows = self.set_facet_col_row_dimensions(
+            ncols, nrows = set_facet_col_row_dimensions(self.xlabels, self.ylabels, 
                 multi_scenario=self.Scenarios
             )
 
@@ -137,13 +154,13 @@ class ThermalReserve(PlotDataStoreAndProcessor):
                     f"generator_Generation{data_resolution}"
                 ].get(scenario)
                 if shift_leapday:
-                    generation = self.adjust_for_leapday(generation)
+                    generation = adjust_for_leapday(generation)
 
                 avail_cap: pd.DataFrame = self[
                     f"generator_Available_Capacity{data_resolution}"
                 ].get(scenario)
                 if shift_leapday:
-                    avail_cap = self.adjust_for_leapday(avail_cap)
+                    avail_cap = adjust_for_leapday(avail_cap)
 
                 # Check if zone is in avail_cap
                 try:
@@ -166,7 +183,7 @@ class ThermalReserve(PlotDataStoreAndProcessor):
                 # Convert units
                 if i == 0:
                     unitconversion = self.capacity_energy_unitconversion(
-                        thermal_reserve, sum_values=True
+                        thermal_reserve, self.Scenarios, sum_values=True
                     )
                 thermal_reserve = thermal_reserve / unitconversion["divisor"]
 
@@ -177,7 +194,7 @@ class ThermalReserve(PlotDataStoreAndProcessor):
                     continue
 
                 if pd.notna(start_date_range):
-                    thermal_reserve = self.set_timestamp_date_range(
+                    thermal_reserve = set_timestamp_date_range(
                         thermal_reserve, start_date_range, end_date_range
                     )
                     if thermal_reserve.empty is True:

--- a/marmot/plottingmodules/thermal_cap_reserve.py
+++ b/marmot/plottingmodules/thermal_cap_reserve.py
@@ -10,11 +10,13 @@ available but not committed (i.e in reserve)
 import logging
 import pandas as pd
 import matplotlib.pyplot as plt
+from typing import List
 
 import marmot.utils.mconfig as mconfig
 
+from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -25,28 +27,45 @@ plot_data_settings: dict = mconfig.parser("plot_data")
 shift_leapday: bool = mconfig.parser("shift_leapday")
 
 
-class ThermalReserve(MPlotDataHelper):
+class ThermalReserve(PlotDataStoreAndProcessor):
     """Thermal capacity in reserve plots.
 
     The thermal_cap_reserve module contains methods that
     display the amount of generation in reserve, i.e non committed capacity.
 
-    ThermalReserve inherits from the MPlotDataHelper class to assist
+    ThermalReserve inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args,
+        marmot_color_dict: dict = None,
+        ylabels: List[str] = None,
+        xlabels: List[str] = None,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        if marmot_color_dict is None:
+            self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
+        else:
+            self.marmot_color_dict = marmot_color_dict
+        self.ylabels = ylabels
+        self.xlabels = xlabels
+
 
     def thermal_cap_reserves(
         self,
@@ -84,7 +103,7 @@ class ThermalReserve(MPlotDataHelper):
             (True, f"generator_Available_Capacity{data_resolution}", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -175,7 +194,7 @@ class ThermalReserve(MPlotDataHelper):
 
                 mplt.stackplot(
                     thermal_reserve,
-                    color_dict=self.PLEXOS_color_dict,
+                    color_dict=self.marmot_color_dict,
                     labels=thermal_reserve.columns,
                     sub_pos=i,
                 )

--- a/marmot/plottingmodules/total_generation.py
+++ b/marmot/plottingmodules/total_generation.py
@@ -26,8 +26,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 logger = logging.getLogger("plotter." + __name__)
 shift_leapday: bool = mconfig.parser("shift_leapday")
 plot_data_settings: dict = mconfig.parser("plot_data")
-load_legend_names: dict = mconfig.parser("load_legend_names")
-
+curtailment_prop: str = mconfig.parser("plot_data", "curtailment_property")
 
 class TotalGeneration(PlotDataStoreAndProcessor):
     """Total generation plots.
@@ -87,7 +86,6 @@ class TotalGeneration(PlotDataStoreAndProcessor):
         self.xlabels = xlabels
         self.custom_xticklabels = custom_xticklabels
 
-        self.curtailment_prop = mconfig.parser("plot_data", "curtailment_property")
 
     def total_gen(
         self,
@@ -128,7 +126,7 @@ class TotalGeneration(PlotDataStoreAndProcessor):
         # scenarios must be a list.
         properties = [
             (True, "generator_Generation", self.Scenarios),
-            (False, f"generator_{self.curtailment_prop}", self.Scenarios),
+            (False, f"generator_{curtailment_prop}", self.Scenarios),
             (False, f"{agg}_Load", self.Scenarios),
             (False, f"{agg}_Demand", self.Scenarios),
             (False, f"{agg}_Unserved_Energy", self.Scenarios),
@@ -318,7 +316,7 @@ class TotalGeneration(PlotDataStoreAndProcessor):
         # scenarios must be a list.
         properties = [
             (True, "generator_Generation", self.Scenarios),
-            (False, f"generator_{self.curtailment_prop}", self.Scenarios),
+            (False, f"generator_{curtailment_prop}", self.Scenarios),
         ]
 
         # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
@@ -543,7 +541,7 @@ class TotalGeneration(PlotDataStoreAndProcessor):
         # scenarios must be a list.
         properties = [
             (True, "generator_Generation", self.Scenarios),
-            (False, f"generator_{self.curtailment_prop}", self.Scenarios),
+            (False, f"generator_{curtailment_prop}", self.Scenarios),
             (False, f"{agg}_Load", self.Scenarios),
             (False, f"{agg}_Demand", self.Scenarios),
         ]
@@ -809,7 +807,7 @@ class TotalGeneration(PlotDataStoreAndProcessor):
         # scenarios must be a list.
         properties = [
             (True, "generator_Generation", self.Scenarios),
-            (False, f"generator_{self.curtailment_prop}", self.Scenarios),
+            (False, f"generator_{curtailment_prop}", self.Scenarios),
         ]
 
         # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary

--- a/marmot/plottingmodules/total_installed_capacity.py
+++ b/marmot/plottingmodules/total_installed_capacity.py
@@ -26,7 +26,6 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 
 logger = logging.getLogger("plotter." + __name__)
 plot_data_settings: dict = mconfig.parser("plot_data")
-load_legend_names: dict = mconfig.parser("load_legend_names")
 
 
 class InstalledCapacity(PlotDataStoreAndProcessor):

--- a/marmot/plottingmodules/transmission.py
+++ b/marmot/plottingmodules/transmission.py
@@ -15,11 +15,13 @@ import matplotlib.pyplot as plt
 import matplotlib.cm as cm
 import matplotlib.colors as mcolors
 import matplotlib.dates as mdates
+from typing import List
 
 import marmot.utils.mconfig as mconfig
 from marmot.metamanagers.read_metadata import MetaData
+from marmot.plottingmodules.plotutils.styles import ColorList
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (MissingInputData, DataSavedInModule,
             UnderDevelopment, InputSheetError, MissingMetaData, UnsupportedAggregation, MissingZoneData)
 
@@ -27,28 +29,45 @@ logger = logging.getLogger('plotter.'+__name__)
 plot_data_settings = mconfig.parser("plot_data")
 shift_leapday : bool = mconfig.parser("shift_leapday")
 
-class Transmission(MPlotDataHelper):
+class Transmission(PlotDataStoreAndProcessor):
     """System transmission plots.
 
     The transmission.py module contains methods that are
     related to the transmission network.
 
-    Transmission inherits from the MPlotDataHelper class to assist 
+    Transmission inherits from the PlotDataStoreAndProcessor class to assist 
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args,
+        ylabels: List[str] = None,
+        xlabels: List[str] = None,
+        custom_xticklabels: List[str] = None,
+        color_list: list = ColorList().colors,
+        Region_Mapping: pd.DataFrame = pd.DataFrame(),
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper
+                Minimum required parameters passed to the PlotDataStoreAndProcessor
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper
+                These parameters will be passed to the PlotDataStoreAndProcessor
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        self.ylabels = ylabels
+        self.xlabels = xlabels
+        self.custom_xticklabels = custom_xticklabels
+        self.color_list = color_list
+        self.Region_Mapping = Region_Mapping
 
         self.font_defaults = mconfig.parser("font_settings")
         self.meta = MetaData(self.processed_hdf5_folder,
@@ -115,7 +134,7 @@ class Transmission(MPlotDataHelper):
         properties = [(True, "line_Flow", self.Scenarios),
                       (True, "line_Import_Limit", self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -283,7 +302,7 @@ class Transmission(MPlotDataHelper):
     #                   (True,"interface_Import_Limit",self.Scenarios),
     #                   (True,"interface_Export_Limit",self.Scenarios)]
         
-    #     # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+    #     # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
     #     # with all required properties, returns a 1 if required data is missing
     #     check_input_data = self.get_formatted_data(properties)
 
@@ -498,7 +517,7 @@ class Transmission(MPlotDataHelper):
                       (True,"interface_Import_Limit",self.Scenarios),
                       (True,"interface_Export_Limit",self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
         
@@ -998,7 +1017,7 @@ class Transmission(MPlotDataHelper):
                       (False, f"{connection}_Import_Limit",self.Scenarios),
                       (False, f"{connection}_Export_Limit",self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
         
@@ -1143,7 +1162,7 @@ class Transmission(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True,"line_Flow",self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -1270,7 +1289,7 @@ class Transmission(MPlotDataHelper):
                       (True,"line_Import_Limit",self.Scenarios),
                       (True,"line_Export_Limit",self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -1512,7 +1531,7 @@ class Transmission(MPlotDataHelper):
 
         properties = [(True,f"{agg}_{agg}s_Net_Interchange",self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
         
@@ -1996,7 +2015,7 @@ class Transmission(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True,f"{agg}_{agg}s_Net_Interchange",scenario_type)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
         
@@ -2146,7 +2165,7 @@ class Transmission(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True,f"{agg}_{agg}s_Net_Interchange",self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
         
@@ -2294,7 +2313,7 @@ class Transmission(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "line_Violation", self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
         
@@ -2413,7 +2432,7 @@ class Transmission(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True,f"{agg}_Net_Interchange",self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
         
@@ -2515,7 +2534,7 @@ class Transmission(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "line_Flow", self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -2685,7 +2704,7 @@ class Transmission(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True,"line_Flow",self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -2834,7 +2853,7 @@ class Transmission(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True,"interface_Flow",self.Scenarios)]
         
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary  
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary  
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 

--- a/marmot/plottingmodules/transmission.py
+++ b/marmot/plottingmodules/transmission.py
@@ -29,8 +29,11 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (MissingInputData, 
             UnderDevelopment, InputSheetError, MissingMetaData, UnsupportedAggregation, MissingZoneData)
 
 logger = logging.getLogger('plotter.'+__name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 shift_leapday : bool = mconfig.parser("shift_leapday")
+xdimension = mconfig.parser("figure_size","xdimension")
+ydimension = mconfig.parser("figure_size","ydimension")
+
 
 class Transmission(PlotDataStoreAndProcessor):
     """System transmission plots.
@@ -100,7 +103,6 @@ class Transmission(PlotDataStoreAndProcessor):
         self.color_list = color_list
         self.Region_Mapping = Region_Mapping
 
-        self.font_defaults = mconfig.parser("font_settings")
         self.meta = MetaData(self.processed_hdf5_folder,
                             Region_Mapping=self.Region_Mapping)
 
@@ -1888,8 +1890,6 @@ class Transmission(PlotDataStoreAndProcessor):
             
             grouped_import_lims = import_lim.groupby(['line_name']).mean().reset_index()
             grouped_export_lims = export_lim.groupby(['line_name']).mean().reset_index()
-            xdimension = mconfig.parser("figure_size","xdimension")
-            ydimension = mconfig.parser("figure_size","ydimension")
 
             #convert values to appropriate units?
             unitconversion = self.capacity_energy_unitconversion(max(grouped_import_lims["values"].values.max(), grouped_export_lims["values"].values.max()), 
@@ -1952,7 +1952,7 @@ class Transmission(PlotDataStoreAndProcessor):
                 axs[0].tick_params(axis='y', which='major', length=5, width=1)
                 axs[0].tick_params(axis='x', which='major', length=5, width=1)
                 axs[0].get_legend().remove()
-                if mconfig.parser("plot_title_as_region"):
+                if plot_data_settings["plot_title_as_region"]:
                     axs[0].set_title(zone_input)
                 
                 # right panel
@@ -1968,7 +1968,7 @@ class Transmission(PlotDataStoreAndProcessor):
                 axs[1].tick_params(axis='y', which='major', length=5, width=1)
                 axs[1].tick_params(axis='x', which='major', length=5, width=1)
 
-                if mconfig.parser("plot_title_as_region"):
+                if plot_data_settings["plot_title_as_region"]:
                     axs[0].set_title(zone_input)
 
                 # create custom line legend

--- a/marmot/plottingmodules/unserved_energy.py
+++ b/marmot/plottingmodules/unserved_energy.py
@@ -9,11 +9,12 @@ plots and is called from marmot_plot_main.py
 
 import logging
 import pandas as pd
+from typing import List
 
 import marmot.utils.mconfig as mconfig
-
+from marmot.plottingmodules.plotutils.styles import ColorList
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -23,28 +24,39 @@ logger = logging.getLogger("plotter." + __name__)
 plot_data_settings = mconfig.parser("plot_data")
 
 
-class UnservedEnergy(MPlotDataHelper):
+class UnservedEnergy(PlotDataStoreAndProcessor):
     """System unserved energy plots.
 
     The unserved_energy.py module contains methods that are
     related to unserved energy in the power system.
 
-    UnservedEnergy inherits from the MPlotDataHelper class to assist
+    UnservedEnergy inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args,
+        custom_xticklabels: List[str] = None,
+        color_list: list = ColorList().colors,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        self.custom_xticklabels = custom_xticklabels
+        self.color_list = color_list
 
     def unserved_energy_timeseries(
         self,
@@ -83,7 +95,7 @@ class UnservedEnergy(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, f"{agg}_Unserved_Energy{data_resolution}", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -202,7 +214,7 @@ class UnservedEnergy(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, f"{agg}_Unserved_Energy", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -350,8 +362,8 @@ class UnservedEnergy(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, f"{agg}_Unserved_Energy", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate
-        # MPlotDataHelper dictionary with all required properties,
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate
+        # PlotDataStoreAndProcessor dictionary with all required properties,
         # returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 

--- a/marmot/plottingmodules/unserved_energy.py
+++ b/marmot/plottingmodules/unserved_energy.py
@@ -10,11 +10,13 @@ plots and is called from marmot_plot_main.py
 import logging
 import pandas as pd
 from typing import List
+from pathlib import Path
 
 import marmot.utils.mconfig as mconfig
 from marmot.plottingmodules.plotutils.styles import ColorList
 from marmot.plottingmodules.plotutils.plot_library import PlotLibrary
-from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor, GenCategories
+from marmot.plottingmodules.plotutils.timeseries_modifiers import set_timestamp_date_range, get_sub_hour_interval_count
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     MissingZoneData,
@@ -37,21 +39,28 @@ class UnservedEnergy(PlotDataStoreAndProcessor):
     def __init__(self, 
         Zones: List[str], 
         Scenarios: List[str], 
-        *args,
+        AGG_BY: str,
+        ordered_gen: List[str],
+        marmot_solutions_folder: Path,
         custom_xticklabels: List[str] = None,
         color_list: list = ColorList().colors,
         **kwargs):
         """
         Args:
-            *args
-                Minimum required parameters passed to the PlotDataStoreAndProcessor 
-                class.
-            **kwargs
-                These parameters will be passed to the PlotDataStoreAndProcessor 
-                class.
+            Zones (List[str]): List of regions/zones to plot.
+            Scenarios (List[str]): List of scenarios to plot.
+            AGG_BY (str): Informs region type to aggregate by when creating plots.
+            ordered_gen (List[str]): Ordered list of generator technologies to plot,
+                order defines the generator technology position in stacked bar and area plots.
+            marmot_solutions_folder (Path): Directory containing Marmot solution outputs.
+            custom_xticklabels (List[str], optional): List of custom x labels to 
+                apply to barplots. Values will overwite existing ones. 
+                Defaults to None.
+            color_list (list, optional): List of colors to apply to non-gen plots.
+                Defaults to ColorList().colors.
         """
-        # Instantiation of MPlotHelperFunctions
-        super().__init__(*args, **kwargs)
+        # Instantiation of PlotDataStoreAndProcessor
+        super().__init__(AGG_BY, ordered_gen, marmot_solutions_folder, **kwargs)
 
         self.Zones = Zones
         self.Scenarios = Scenarios
@@ -116,7 +125,7 @@ class UnservedEnergy(PlotDataStoreAndProcessor):
                 unserved_energy = unserved_energy.groupby(["timestamp"]).sum()
 
                 if pd.notna(start_date_range):
-                    unserved_energy = self.set_timestamp_date_range(
+                    unserved_energy = set_timestamp_date_range(
                         unserved_energy, start_date_range, end_date_range
                     )
                     if unserved_energy.empty is True:
@@ -140,7 +149,7 @@ class UnservedEnergy(PlotDataStoreAndProcessor):
                 continue
 
             # Determine auto unit coversion
-            unitconversion = self.capacity_energy_unitconversion(unserved_energy_out)
+            unitconversion = self.capacity_energy_unitconversion(unserved_energy_out, self.Scenarios)
             unserved_energy_out = unserved_energy_out / unitconversion["divisor"]
 
             # Data table of values to return to main program
@@ -235,10 +244,10 @@ class UnservedEnergy(PlotDataStoreAndProcessor):
                 unserved_energy = unserved_energy.groupby(["timestamp"]).sum()
 
                 # correct sum for non-hourly runs
-                interval_count = self.get_sub_hour_interval_count(unserved_energy)
+                interval_count = get_sub_hour_interval_count(unserved_energy)
                 unserved_energy = unserved_energy / interval_count
                 if pd.notna(start_date_range):
-                    unserved_energy = self.set_timestamp_date_range(
+                    unserved_energy = set_timestamp_date_range(
                         unserved_energy, start_date_range, end_date_range
                     )
                     if unserved_energy.empty is True:
@@ -268,7 +277,7 @@ class UnservedEnergy(PlotDataStoreAndProcessor):
                 continue
 
             # Determine auto unit coversion
-            unitconversion = self.capacity_energy_unitconversion(unserved_energy_out)
+            unitconversion = self.capacity_energy_unitconversion(unserved_energy_out, self.Scenarios)
             unserved_energy_out = unserved_energy_out / unitconversion["divisor"]
 
             # Data table of values to return to main program
@@ -386,14 +395,14 @@ class UnservedEnergy(PlotDataStoreAndProcessor):
                 unserved_energy = unserved_energy.groupby(["timestamp"]).sum()
 
                 if pd.notna(start_date_range):
-                    unserved_energy = self.set_timestamp_date_range(
+                    unserved_energy = set_timestamp_date_range(
                         unserved_energy, start_date_range, end_date_range
                     )
                     if unserved_energy.empty is True:
                         logger.warning("No Unserved Energy in selected Date Range")
                         continue
 
-                interval_count = self.get_sub_hour_interval_count(unserved_energy)
+                interval_count = get_sub_hour_interval_count(unserved_energy)
                 unserved_energy = unserved_energy / interval_count
                 # Group data by hours and find mean across entire range
                 unserved_energy = self.year_scenario_grouper(
@@ -427,7 +436,7 @@ class UnservedEnergy(PlotDataStoreAndProcessor):
             mplt = PlotLibrary()
             fig, ax = mplt.get_figure()
 
-            unitconversion = self.capacity_energy_unitconversion(unserved_energy_out)
+            unitconversion = self.capacity_energy_unitconversion(unserved_energy_out, self.Scenarios)
             unserved_energy_out = unserved_energy_out / unitconversion["divisor"]
             Data_Table_Out = unserved_energy_out
             Data_Table_Out = Data_Table_Out.add_suffix(f" ({unitconversion['units']})")

--- a/marmot/plottingmodules/unserved_energy.py
+++ b/marmot/plottingmodules/unserved_energy.py
@@ -23,7 +23,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 
 
 class UnservedEnergy(PlotDataStoreAndProcessor):

--- a/marmot/plottingmodules/utilization_factor.py
+++ b/marmot/plottingmodules/utilization_factor.py
@@ -16,10 +16,11 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from typing import List
+from pathlib import Path
 
 import marmot.utils.mconfig as mconfig
 from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
-from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor, GenCategories
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     UnderDevelopment,
@@ -57,23 +58,33 @@ class UtilizationFactor(PlotDataStoreAndProcessor):
     def __init__(self, 
         Zones: List[str], 
         Scenarios: List[str], 
-        *args,
+        AGG_BY: str,
+        ordered_gen: List[str],
+        marmot_solutions_folder: Path,
+        gen_categories: GenCategories = GenCategories(),
         marmot_color_dict: dict = None,
         **kwargs):
         """
         Args:
-            *args
-                Minimum required parameters passed to the PlotDataStoreAndProcessor 
-                class.
-            **kwargs
-                These parameters will be passed to the PlotDataStoreAndProcessor 
-                class.
+            Zones (List[str]): List of regions/zones to plot.
+            Scenarios (List[str]): List of scenarios to plot.
+            AGG_BY (str): Informs region type to aggregate by when creating plots.
+            ordered_gen (List[str]): Ordered list of generator technologies to plot,
+                order defines the generator technology position in stacked bar and area plots.
+            marmot_solutions_folder (Path): Directory containing Marmot solution outputs.
+            gen_categories (GenCategories): Instance of GenCategories class, groups generator technologies 
+                into defined categories.
+                Deafults to GenCategories.
+            marmot_color_dict (dict, optional): Dictionary of colors to use for 
+                generation technologies.
+                Defaults to None.
         """
-        # Instantiation of MPlotHelperFunctions
-        super().__init__(*args, **kwargs)
+        # Instantiation of PlotDataStoreAndProcessor
+        super().__init__(AGG_BY, ordered_gen, marmot_solutions_folder, **kwargs)
 
         self.Zones = Zones
         self.Scenarios = Scenarios
+        self.gen_categories = gen_categories
         if marmot_color_dict is None:
             self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
         else:

--- a/marmot/plottingmodules/utilization_factor.py
+++ b/marmot/plottingmodules/utilization_factor.py
@@ -28,7 +28,7 @@ from marmot.plottingmodules.plotutils.plot_exceptions import (
 )
 
 logger = logging.getLogger("plotter." + __name__)
-plot_data_settings = mconfig.parser("plot_data")
+plot_data_settings: dict = mconfig.parser("plot_data")
 
 
 def df_process_gen_ind_inputs(df, self):

--- a/marmot/plottingmodules/utilization_factor.py
+++ b/marmot/plottingmodules/utilization_factor.py
@@ -15,10 +15,11 @@ import logging
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+from typing import List
 
 import marmot.utils.mconfig as mconfig
-
-from marmot.plottingmodules.plotutils.plot_data_helper import MPlotDataHelper
+from marmot.plottingmodules.plotutils.styles import GeneratorColorDict
+from marmot.plottingmodules.plotutils.plot_data_helper import PlotDataStoreAndProcessor
 from marmot.plottingmodules.plotutils.plot_exceptions import (
     MissingInputData,
     UnderDevelopment,
@@ -40,32 +41,43 @@ def df_process_gen_ind_inputs(df, self):
     df = df.sort_values(["tech"])
     df.set_index(["timestamp", "tech", "gen_name"], inplace=True)
     df = df["values"]
-
     return df
 
 
-class UtilizationFactor(MPlotDataHelper):
+class UtilizationFactor(PlotDataStoreAndProcessor):
     """Device utilization plots.
 
     The utilization.py module contains methods that are
     related to the utilization of generators and other devices.
 
-    UtilizationFactor inherits from the MPlotDataHelper class to assist
+    UtilizationFactor inherits from the PlotDataStoreAndProcessor class to assist
     in creating figures.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, 
+        Zones: List[str], 
+        Scenarios: List[str], 
+        *args,
+        marmot_color_dict: dict = None,
+        **kwargs):
         """
         Args:
             *args
-                Minimum required parameters passed to the MPlotDataHelper 
+                Minimum required parameters passed to the PlotDataStoreAndProcessor 
                 class.
             **kwargs
-                These parameters will be passed to the MPlotDataHelper 
+                These parameters will be passed to the PlotDataStoreAndProcessor 
                 class.
         """
         # Instantiation of MPlotHelperFunctions
         super().__init__(*args, **kwargs)
+
+        self.Zones = Zones
+        self.Scenarios = Scenarios
+        if marmot_color_dict is None:
+            self.marmot_color_dict = GeneratorColorDict.set_random_colors(self.ordered_gen).color_dict
+        else:
+            self.marmot_color_dict = marmot_color_dict
 
     def uf_fleet(self, **_):
         """Plot under development
@@ -86,7 +98,7 @@ class UtilizationFactor(MPlotDataHelper):
             (True, "generator_Available_Capacity", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -142,7 +154,7 @@ class UtilizationFactor(MPlotDataHelper):
                     if len(self.Scenarios) > 1:
                         ax3[n].plot(
                             duration_curve["Type CF"],
-                            color=self.PLEXOS_color_dict.get(i, "#333333"),
+                            color=self.marmot_color_dict.get(i, "#333333"),
                             label=i,
                         )
                         ax3[n].legend()
@@ -158,7 +170,7 @@ class UtilizationFactor(MPlotDataHelper):
                     else:
                         ax3.plot(
                             duration_curve["Type CF"],
-                            color=self.PLEXOS_color_dict.get(i, "#333333"),
+                            color=self.marmot_color_dict.get(i, "#333333"),
                             label=i,
                         )
                         ax3.legend()
@@ -224,7 +236,7 @@ class UtilizationFactor(MPlotDataHelper):
             (True, "generator_Available_Capacity", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -282,7 +294,7 @@ class UtilizationFactor(MPlotDataHelper):
                             cfs.replace([np.inf, np.nan]),
                             bins=20,
                             range=(0, 1),
-                            color=self.PLEXOS_color_dict.get(i, "#333333"),
+                            color=self.marmot_color_dict.get(i, "#333333"),
                             label=scenario + "_" + i,
                         )
                         ax2[len(self.Scenarios) - 1][m].set_xlabel(
@@ -299,7 +311,7 @@ class UtilizationFactor(MPlotDataHelper):
                             cfs.replace([np.inf, np.nan]),
                             bins=20,
                             range=(0, 1),
-                            color=self.PLEXOS_color_dict.get(i, "#333333"),
+                            color=self.marmot_color_dict.get(i, "#333333"),
                             label=scenario + "_" + i,
                         )
                         ax2[m].legend()
@@ -369,7 +381,7 @@ class UtilizationFactor(MPlotDataHelper):
             (True, "generator_Available_Capacity", self.Scenarios),
         ]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -485,7 +497,7 @@ class UtilizationFactor(MPlotDataHelper):
         # scenarios must be a list.
         properties = [(True, "generator_Generation", self.Scenarios)]
 
-        # Runs get_formatted_data within MPlotDataHelper to populate MPlotDataHelper dictionary
+        # Runs get_formatted_data within PlotDataStoreAndProcessor to populate PlotDataStoreAndProcessor dictionary
         # with all required properties, returns a 1 if required data is missing
         check_input_data = self.get_formatted_data(properties)
 
@@ -528,7 +540,7 @@ class UtilizationFactor(MPlotDataHelper):
                     if len(self.Scenarios) > 1:
                         ax3[n].plot(
                             duration_curve["values"] / 1000,
-                            color=self.PLEXOS_color_dict.get(i, "#333333"),
+                            color=self.marmot_color_dict.get(i, "#333333"),
                             label=i,
                         )
                         ax3[n].legend()
@@ -544,7 +556,7 @@ class UtilizationFactor(MPlotDataHelper):
                     else:
                         ax3.plot(
                             duration_curve["values"] / 1000,
-                            color=self.PLEXOS_color_dict.get(i, "#333333"),
+                            color=self.marmot_color_dict.get(i, "#333333"),
                             label=i,
                         )
                         ax3.legend()


### PR DESCRIPTION
- adds styles module containing dataclasses for colors and markers
- new timeseries_modifiers module, collection of functions used to modify timeseries data.
- MPlotDataHelper now named PlotDataStoreAndProcessor
- moved methods that arnt directly related to  modifying dataframe columns and storing data from PlotDataStoreAndProcessor
- instance of GenCategories no longer created within module, now handled in main.
- All plotting classes now take all required args as input. Only kwargs that are required in parent class now passed